### PR TITLE
Add scripted tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ $ sbt
 > graphqlValidateSchema build prod
 ```
 
+## Schema rendering
+
+You can render every schema with the `graphqlRenderSchema` task. In your sbt shell
+
+```sbt
+> graphqlRenderSchema build
+```
+
+This will render the `build` schema.
+
+You can configure the target directory with
+
+```scala
+target in graphqlRenderSchema := target.value / "graphql-schema"
+```
+
 ## Schema release notes
 
 `sbt-graphql` creates release notes from changes between two schemas. The format is currently markdown.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Now you can generate a schema with
 $ sbt graphqlSchemaGen
 ```
 
+You can configure the output directory in your `build.sbt` with
+
+```scala
+target in graphqlSchemaGen := target.value / "grapqhl-build-schema"
+```
+
 ## Schema definitions
 
 Your build can contain multiple schemas. They are stored in the `graphqlSchemas` setting.

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,10 @@ libraryDependencies ++= Seq(
   "org.scalaj" %% "scalaj-http" % "2.3.0"
 )
 
+// scripted test settings
+scriptedLaunchOpts += "-Dproject.version=" + version.value
+
+// project meta data
 licenses := Seq(
   "Apache-2.0" -> url("https://opensource.org/licenses/Apache-2.0"))
 homepage := Some(url("https://github.com/muuki88/sbt-graphql"))

--- a/build.sbt
+++ b/build.sbt
@@ -77,4 +77,4 @@ pgpPassphrase := sys.env.get("PGP_PASS").map(_.toArray)
 // ci commands
 addCommandAlias("validateFormatting",
                 "; scalafmt::test ; test:scalafmt::test ; sbt:scalafmt::test")
-addCommandAlias("validate", "; clean ; update ; validateFormatting ; test")
+addCommandAlias("validate", "; clean ; update ; validateFormatting ; test ; scripted")

--- a/build.sbt
+++ b/build.sbt
@@ -77,4 +77,5 @@ pgpPassphrase := sys.env.get("PGP_PASS").map(_.toArray)
 // ci commands
 addCommandAlias("validateFormatting",
                 "; scalafmt::test ; test:scalafmt::test ; sbt:scalafmt::test")
-addCommandAlias("validate", "; clean ; update ; validateFormatting ; test ; scripted")
+addCommandAlias("validate",
+                "; clean ; update ; validateFormatting ; test ; scripted")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,6 @@ addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.1")
 
 // plugin project
 libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-MF"
+
+// testing
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
@@ -118,8 +118,9 @@ object GraphQLSchemaPlugin extends AutoPlugin {
     graphqlSchemaSnippet := """sys.error("Configure the `graphqlSchemaSnippet` setting with the correct scala code snippet to access your sangria schema")""",
     graphqlProductionSchema := Schema.buildFromAst(Document.emptyStub),
     graphqlSchemaChanges := graphqlSchemaChangesTask.evaluated,
+    target in graphqlSchemaGen := (target in Compile).value / "sbt-graphql",
     graphqlSchemaGen := {
-      val schemaFile = resourceManaged.value / "sbt-graphql" / "schema.graphql"
+      val schemaFile = (target in graphqlSchemaGen).value / "schema.graphql"
       runner.value.run(
         s"$packageName.$mainClass",
         Attributed.data((fullClasspath in Compile).value),

--- a/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
@@ -72,6 +72,13 @@ object GraphQLSchemaPlugin extends AutoPlugin {
       taskKey[File]("generates a graphql schema file")
 
     /**
+      * Renders the given schema into a graphql file.
+      * The input is the label in the graphqlSchemas setting.
+      */
+    val graphqlRenderSchema: InputKey[File] =
+      inputKey[File]("renders the given schema to a graphql file")
+
+    /**
       * Returns the changes between the two schemas defined as parameters.
       *
       * `graphqlSchemaChanges <new schema> <old schema>`
@@ -149,7 +156,10 @@ object GraphQLSchemaPlugin extends AutoPlugin {
             .loadSchema()
         )
         .taskValue
-    )
+    ),
+    // schema rendering
+    target in graphqlRenderSchema := (target in Compile).value / "grapqhl",
+    graphqlRenderSchema := graphqlRenderSchemaTask.evaluated
   )
 
   /**
@@ -194,6 +204,13 @@ object GraphQLSchemaPlugin extends AutoPlugin {
     token(Space ~> schemaParser)
   }
 
+  private val singleSchemaLabelParser: Def.Initialize[Parser[String]] =
+    Def.setting {
+      val labels = graphqlSchemas.value.schemas.map(_.label)
+      // create a depened parser. A label can only be selected once
+      schemaLabelParser(labels)
+    }
+
   /**
     * Parses two schema labels
     */
@@ -228,6 +245,24 @@ object GraphQLSchemaPlugin extends AutoPlugin {
       breakingChanges.foreach(change => log.error(s" * ${change.description}"))
       quietError("Validation failed: Breaking changes found")
     }
+  }
+
+  private val graphqlRenderSchemaTask = Def.inputTaskDyn[File] {
+    val log = streams.value.log
+    val label = singleSchemaLabelParser.parsed
+    val file = (target in graphqlRenderSchema).value / s"$label.graphql"
+    val schemaDefinition = graphqlSchemas.value.schemaByLabel.getOrElse(
+      label,
+      sys.error(s"The schema '$label' is not defined in graphqlSchemas")
+    )
+    log.info(s"Rendering schema to: ${file.getPath}")
+
+    Def.task {
+      val schema = schemaDefinition.schemaTask.value
+      IO.write(file, schema.renderPretty)
+      file
+    }
+
   }
 
 }

--- a/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
@@ -208,7 +208,7 @@ object GraphQLSchemaPlugin extends AutoPlugin {
   private val singleSchemaLabelParser: Def.Initialize[Parser[String]] =
     Def.setting {
       val labels = graphqlSchemas.value.schemas.map(_.label)
-      // create a depened parser. A label can only be selected once
+      // create a dependent parser. A label can only be selected once
       schemaLabelParser(labels)
     }
 

--- a/src/sbt-test/schema/schema-snippet/build.sbt
+++ b/src/sbt-test/schema/schema-snippet/build.sbt
@@ -1,0 +1,10 @@
+name := "query-validation"
+
+enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
+
+graphqlSchemaSnippet := "example.ProductSchema.schema"
+
+libraryDependencies ++= Seq(
+  "org.sangria-graphql" %% "sangria" % "1.3.0",
+  "org.sangria-graphql" %% "sangria-circe" % "1.1.0"
+)

--- a/src/sbt-test/schema/schema-snippet/project/plugins.sbt
+++ b/src/sbt-test/schema/schema-snippet/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("rocks.muki" % "sbt-graphql" % sys.props("project.version"))

--- a/src/sbt-test/schema/schema-snippet/schemas/product-broken.graphql
+++ b/src/sbt-test/schema/schema-snippet/schemas/product-broken.graphql
@@ -1,0 +1,29 @@
+# Entity that can be identified
+interface Identifiable {
+  id: String!
+}
+
+# The product picture
+type Picture {
+  width: Int!
+  height: Int!
+
+  # Picture CDN URL
+  url: String
+}
+
+type Product implements Identifiable {
+  id: String!
+  name: String!
+  breakingChangeField: String!
+  description: String!
+  picture(size: Int!): Picture!
+}
+
+type Query {
+  # Returns a product with specific `id`.
+  product(id: String!): Product
+
+  # Returns a list of all available products.
+  products: [Product!]!
+}

--- a/src/sbt-test/schema/schema-snippet/schemas/product.graphql
+++ b/src/sbt-test/schema/schema-snippet/schemas/product.graphql
@@ -1,0 +1,28 @@
+# Entity that can be identified
+interface Identifiable {
+  id: String!
+}
+
+# The product picture
+type Picture {
+  width: Int!
+  height: Int!
+
+  # Picture CDN URL
+  url: String
+}
+
+type Product implements Identifiable {
+  id: String!
+  name: String!
+  description: String!
+  picture(size: Int!): Picture!
+}
+
+type Query {
+  # Returns a product with specific `id`.
+  product(id: String!): Product
+
+  # Returns a list of all available products.
+  products: [Product!]!
+}

--- a/src/sbt-test/schema/schema-snippet/src/main/scala/example/ProductSchema.scala
+++ b/src/sbt-test/schema/schema-snippet/src/main/scala/example/ProductSchema.scala
@@ -1,0 +1,72 @@
+package example
+
+import sangria._
+import sangria.schema._
+import sangria.macros.derive._
+
+// From the Sangria getting started guide
+// http://sangria-graphql.org/getting-started/
+
+trait Identifiable {
+  def id: String
+}
+
+case class Picture(width: Int, height: Int, url: Option[String])
+case class Product(id: String, name: String, description: String) extends Identifiable {
+  def picture(size: Int): Picture =
+    Picture(width = size, height = size, url = Some(s"//cdn.com/$size/$id.jpg"))
+}
+
+object ProductSchema {
+
+  implicit val PictureType = ObjectType(
+    "Picture",
+    "The product picture",
+
+    fields[Unit, Picture](
+      Field("width", IntType, resolve = _.value.width),
+      Field("height", IntType, resolve = _.value.height),
+      Field("url", OptionType(StringType),
+        description = Some("Picture CDN URL"),
+        resolve = _.value.url)))
+
+  val IdentifiableType = InterfaceType(
+    "Identifiable",
+    "Entity that can be identified",
+
+    fields[Unit, Identifiable](
+      Field("id", StringType, resolve = _.value.id)))
+
+  val ProductType =
+    deriveObjectType[Unit, Product](
+      Interfaces(IdentifiableType),
+      IncludeMethods("picture"))
+
+
+  val Id = Argument("id", StringType)
+
+  val QueryType = ObjectType("Query", fields[ProductRepo, Unit](
+    Field("product", OptionType(ProductType),
+      description = Some("Returns a product with specific `id`."),
+      arguments = Id :: Nil,
+      resolve = c ⇒ c.ctx.product(c arg Id)),
+
+    Field("products", ListType(ProductType),
+      description = Some("Returns a list of all available products."),
+      resolve = _.ctx.products)))
+
+  val schema = Schema(QueryType)
+
+}
+
+class ProductRepo {
+  private val Products = List(
+    Product("1", "Cheesecake", "Tasty"),
+    Product("2", "Health Potion", "+50 HP"))
+
+  def product(id: String): Option[Product] =
+    Products find (_.id == id)
+
+  def products: List[Product] = Products
+}
+

--- a/src/sbt-test/schema/schema-snippet/test
+++ b/src/sbt-test/schema/schema-snippet/test
@@ -1,0 +1,9 @@
+# validate the default settings
+$ absent target/sbt-graphql/schema.graphql
+> graphqlSchemaGen
+$ exists target/sbt-graphql/schema.graphql
+# configure the target folder
+$ absent target/schema.graphql
+> set target in graphqlSchemaGen := (target in Compile).value
+> graphqlSchemaGen
+$ exists target/schema.graphql

--- a/src/sbt-test/validation/query/build.sbt
+++ b/src/sbt-test/validation/query/build.sbt
@@ -1,0 +1,10 @@
+name := "query-validation"
+
+enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
+
+graphqlSchemaSnippet := "example.ProductSchema.schema"
+
+libraryDependencies ++= Seq(
+  "org.sangria-graphql" %% "sangria" % "1.3.0",
+  "org.sangria-graphql" %% "sangria-circe" % "1.1.0"
+)

--- a/src/sbt-test/validation/query/project/plugins.sbt
+++ b/src/sbt-test/validation/query/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("rocks.muki" % "sbt-graphql" % sys.props("project.version"))

--- a/src/sbt-test/validation/query/src/main/graphql/broken.graphql
+++ b/src/sbt-test/validation/query/src/main/graphql/broken.graphql
@@ -1,0 +1,6 @@
+query Product()
+  product(id: "love") {
+     name
+     description
+  }
+}

--- a/src/sbt-test/validation/query/src/main/graphql/product.graphql
+++ b/src/sbt-test/validation/query/src/main/graphql/product.graphql
@@ -1,0 +1,6 @@
+query Product($productId: String!) {
+  product(id: $productId) {
+     name
+     description
+  }
+}

--- a/src/sbt-test/validation/query/src/main/graphql/specificProduct.graphql
+++ b/src/sbt-test/validation/query/src/main/graphql/specificProduct.graphql
@@ -1,0 +1,6 @@
+query SpecificProduct {
+  product(id: "love") {
+     name
+     description
+  }
+}

--- a/src/sbt-test/validation/query/src/main/scala/example/ProductSchema.scala
+++ b/src/sbt-test/validation/query/src/main/scala/example/ProductSchema.scala
@@ -1,0 +1,72 @@
+package example
+
+import sangria._
+import sangria.schema._
+import sangria.macros.derive._
+
+// From the Sangria getting started guide
+// http://sangria-graphql.org/getting-started/
+
+trait Identifiable {
+  def id: String
+}
+
+case class Picture(width: Int, height: Int, url: Option[String])
+case class Product(id: String, name: String, description: String) extends Identifiable {
+  def picture(size: Int): Picture =
+    Picture(width = size, height = size, url = Some(s"//cdn.com/$size/$id.jpg"))
+}
+
+object ProductSchema {
+
+  implicit val PictureType = ObjectType(
+    "Picture",
+    "The product picture",
+
+    fields[Unit, Picture](
+      Field("width", IntType, resolve = _.value.width),
+      Field("height", IntType, resolve = _.value.height),
+      Field("url", OptionType(StringType),
+        description = Some("Picture CDN URL"),
+        resolve = _.value.url)))
+
+  val IdentifiableType = InterfaceType(
+    "Identifiable",
+    "Entity that can be identified",
+
+    fields[Unit, Identifiable](
+      Field("id", StringType, resolve = _.value.id)))
+
+  val ProductType =
+    deriveObjectType[Unit, Product](
+      Interfaces(IdentifiableType),
+      IncludeMethods("picture"))
+
+
+  val Id = Argument("id", StringType)
+
+  val QueryType = ObjectType("Query", fields[ProductRepo, Unit](
+    Field("product", OptionType(ProductType),
+      description = Some("Returns a product with specific `id`."),
+      arguments = Id :: Nil,
+      resolve = c ⇒ c.ctx.product(c arg Id)),
+
+    Field("products", ListType(ProductType),
+      description = Some("Returns a list of all available products."),
+      resolve = _.ctx.products)))
+
+  val schema = Schema(QueryType)
+
+}
+
+class ProductRepo {
+  private val Products = List(
+    Product("1", "Cheesecake", "Tasty"),
+    Product("2", "Health Potion", "+50 HP"))
+
+  def product(id: String): Option[Product] =
+    Products find (_.id == id)
+
+  def products: List[Product] = Products
+}
+

--- a/src/sbt-test/validation/query/test
+++ b/src/sbt-test/validation/query/test
@@ -1,0 +1,4 @@
+# validation should fail with the broken.graphql file
+-> graphqlValidateQueries
+$ delete src/main/graphql/broken.graphql
+> graphqlValidateQueries

--- a/src/sbt-test/validation/schema/build.sbt
+++ b/src/sbt-test/validation/schema/build.sbt
@@ -1,0 +1,30 @@
+name := "query-validation"
+
+enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
+
+graphqlSchemaSnippet := "example.ProductSchema.schema"
+
+libraryDependencies ++= Seq(
+  "org.sangria-graphql" %% "sangria" % "1.3.0",
+  "org.sangria-graphql" %% "sangria-circe" % "1.1.0"
+)
+
+graphqlSchemas += GraphQLSchema(
+  "product-schema",
+  "fixed schema at schemas/product.graphql",
+  Def.task(
+    GraphQLSchemaLoader
+      .fromFile(baseDirectory.value / "schemas" / "product.graphql")
+      .loadSchema()
+  ).taskValue
+)
+
+graphqlSchemas += GraphQLSchema(
+  "product-schema-broken",
+  "fixed schema at schemas/product-broken.graphql",
+  Def.task(
+    GraphQLSchemaLoader
+      .fromFile(baseDirectory.value / "schemas" / "product-broken.graphql")
+      .loadSchema()
+  ).taskValue
+)

--- a/src/sbt-test/validation/schema/project/plugins.sbt
+++ b/src/sbt-test/validation/schema/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("rocks.muki" % "sbt-graphql" % sys.props("project.version"))

--- a/src/sbt-test/validation/schema/schemas/product-broken.graphql
+++ b/src/sbt-test/validation/schema/schemas/product-broken.graphql
@@ -1,0 +1,29 @@
+# Entity that can be identified
+interface Identifiable {
+  id: String!
+}
+
+# The product picture
+type Picture {
+  width: Int!
+  height: Int!
+
+  # Picture CDN URL
+  url: String
+}
+
+type Product implements Identifiable {
+  id: String!
+  name: String!
+  breakingChangeField: String!
+  description: String!
+  picture(size: Int!): Picture!
+}
+
+type Query {
+  # Returns a product with specific `id`.
+  product(id: String!): Product
+
+  # Returns a list of all available products.
+  products: [Product!]!
+}

--- a/src/sbt-test/validation/schema/schemas/product.graphql
+++ b/src/sbt-test/validation/schema/schemas/product.graphql
@@ -1,0 +1,28 @@
+# Entity that can be identified
+interface Identifiable {
+  id: String!
+}
+
+# The product picture
+type Picture {
+  width: Int!
+  height: Int!
+
+  # Picture CDN URL
+  url: String
+}
+
+type Product implements Identifiable {
+  id: String!
+  name: String!
+  description: String!
+  picture(size: Int!): Picture!
+}
+
+type Query {
+  # Returns a product with specific `id`.
+  product(id: String!): Product
+
+  # Returns a list of all available products.
+  products: [Product!]!
+}

--- a/src/sbt-test/validation/schema/src/graphql/broken.graphql
+++ b/src/sbt-test/validation/schema/src/graphql/broken.graphql
@@ -1,0 +1,6 @@
+query Product()
+  product(id: "love") {
+     name
+     description
+  }
+}

--- a/src/sbt-test/validation/schema/src/graphql/product.graphql
+++ b/src/sbt-test/validation/schema/src/graphql/product.graphql
@@ -1,0 +1,6 @@
+query Product($productId: String!) {
+  product(id: $productId) {
+     name
+     description
+  }
+}

--- a/src/sbt-test/validation/schema/src/graphql/specificProduct.graphql
+++ b/src/sbt-test/validation/schema/src/graphql/specificProduct.graphql
@@ -1,0 +1,6 @@
+query SpecificProduct {
+  product(id: "love") {
+     name
+     description
+  }
+}

--- a/src/sbt-test/validation/schema/src/main/scala/example/ProductSchema.scala
+++ b/src/sbt-test/validation/schema/src/main/scala/example/ProductSchema.scala
@@ -1,0 +1,72 @@
+package example
+
+import sangria._
+import sangria.schema._
+import sangria.macros.derive._
+
+// From the Sangria getting started guide
+// http://sangria-graphql.org/getting-started/
+
+trait Identifiable {
+  def id: String
+}
+
+case class Picture(width: Int, height: Int, url: Option[String])
+case class Product(id: String, name: String, description: String) extends Identifiable {
+  def picture(size: Int): Picture =
+    Picture(width = size, height = size, url = Some(s"//cdn.com/$size/$id.jpg"))
+}
+
+object ProductSchema {
+
+  implicit val PictureType = ObjectType(
+    "Picture",
+    "The product picture",
+
+    fields[Unit, Picture](
+      Field("width", IntType, resolve = _.value.width),
+      Field("height", IntType, resolve = _.value.height),
+      Field("url", OptionType(StringType),
+        description = Some("Picture CDN URL"),
+        resolve = _.value.url)))
+
+  val IdentifiableType = InterfaceType(
+    "Identifiable",
+    "Entity that can be identified",
+
+    fields[Unit, Identifiable](
+      Field("id", StringType, resolve = _.value.id)))
+
+  val ProductType =
+    deriveObjectType[Unit, Product](
+      Interfaces(IdentifiableType),
+      IncludeMethods("picture"))
+
+
+  val Id = Argument("id", StringType)
+
+  val QueryType = ObjectType("Query", fields[ProductRepo, Unit](
+    Field("product", OptionType(ProductType),
+      description = Some("Returns a product with specific `id`."),
+      arguments = Id :: Nil,
+      resolve = c ⇒ c.ctx.product(c arg Id)),
+
+    Field("products", ListType(ProductType),
+      description = Some("Returns a list of all available products."),
+      resolve = _.ctx.products)))
+
+  val schema = Schema(QueryType)
+
+}
+
+class ProductRepo {
+  private val Products = List(
+    Product("1", "Cheesecake", "Tasty"),
+    Product("2", "Health Potion", "+50 HP"))
+
+  def product(id: String): Option[Product] =
+    Products find (_.id == id)
+
+  def products: List[Product] = Products
+}
+

--- a/src/sbt-test/validation/schema/test
+++ b/src/sbt-test/validation/schema/test
@@ -1,0 +1,3 @@
+# validation should fail with the broken.graphql file
+> graphqlValidateSchema build product-schema
+-> graphqlValidateSchema build product-schema-broken


### PR DESCRIPTION
Adds scripted tests and a `graphqlRenderSchema` tasks, which generates a `*.graphql` file for a configured schema.

## TODO

* [x] document `graphqlRenderSchema` task
* [x] scripted test for schema generation based on snippet
* [x] run tests on travis