### PR TITLE
Added user defined imports to codegen #29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /project/.gnupg/sec.asc
 target
+.idea/
 
 *.class
 *.log

--- a/src/main/scala/rocks/muki/graphql/GraphQLCodegenPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLCodegenPlugin.scala
@@ -22,6 +22,10 @@ object GraphQLCodegenPlugin extends AutoPlugin {
 
     val graphqlCodegenPackage =
       settingKey[String]("Package for the generated code")
+
+    val graphqlCodegenImports =
+      settingKey[Seq[String]]("Additional imports to add to the generated code")
+
     val graphqlCodegen = taskKey[Seq[File]]("Generate GraphQL API code")
 
     val Apollo = CodeGenStyles.Apollo
@@ -48,6 +52,7 @@ object GraphQLCodegenPlugin extends AutoPlugin {
       .value,
     sourceGenerators in Compile += graphqlCodegen.taskValue,
     graphqlCodegenPackage := "graphql.codegen",
+    graphqlCodegenImports := Seq.empty,
     name in graphqlCodegen := "GraphQLCodegen",
     graphqlCodegen := {
       val log = streams.value.log
@@ -62,9 +67,14 @@ object GraphQLCodegenPlugin extends AutoPlugin {
       val schema =
         SchemaLoader.fromFile(graphqlCodegenSchema.value).loadSchema()
 
+      val imports = graphqlCodegenImports.value
+
       val jsonCodeGen = graphqlCodegenJson.value
       log.info(
         s"Generating json decoding with: ${jsonCodeGen.getClass.getSimpleName}")
+
+      log.info(
+        s"Adding imports: ${imports.mkString(",")}")
 
       val moduleName = (name in graphqlCodegen).value
       val context = CodeGenContext(schema,
@@ -73,6 +83,7 @@ object GraphQLCodegenPlugin extends AutoPlugin {
                                    packageName,
                                    moduleName,
                                    jsonCodeGen,
+                                   imports,
                                    log)
 
       graphqlCodegenStyle.value(context)

--- a/src/main/scala/rocks/muki/graphql/codegen/CodeGenContext.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/CodeGenContext.scala
@@ -15,6 +15,8 @@ import sbt.Logger
   * @param graphQLFiles input files that should be processed
   * @param packageName the scala package name
   * @param moduleName optional module name for single-file based generators
+  * @param jsonCodeGen
+  * @param imports list of imports to be added to the generated file
   * @param log output log
   */
 case class CodeGenContext(
@@ -24,5 +26,6 @@ case class CodeGenContext(
     packageName: String,
     moduleName: String,
     jsonCodeGen: JsonCodeGen,
+    imports: Seq[String],
     log: Logger
 )

--- a/src/main/scala/rocks/muki/graphql/codegen/CodeGenStyles.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/CodeGenStyles.scala
@@ -36,7 +36,23 @@ object CodeGenStyles {
       graphQLQueryFile,
       GraphQLQueryGenerator.sourceCode(context.packageName))
 
-    val additionalImports = GraphQLQueryGenerator.imports(context.packageName)
+    val customImports = {
+      def importer(c: List[String]): List[Importer] = {
+        if (c.last == "_") {
+          Importer(Term.Name(c.init.mkString(".")), List(Importee.Wildcard())) :: Nil
+        } else {
+          Importer(Term.Name(c.init.mkString(".")), List(Importee.Name(Name(c.last)))) :: Nil
+        }
+      }
+
+
+      context.imports.toList.map { x =>
+        val i = importer(x.split("\\.").toList)
+        q"import ..$i"
+      }
+    }
+
+    val additionalImports = GraphQLQueryGenerator.imports(context.packageName) ++ customImports
     val additionalInits = GraphQLQueryGenerator.inits
 
     // Process all the graphql files


### PR DESCRIPTION
This works, but I have no idea if it's the best use of scalameta :). I've never used it before and documentation is kind of scarce.

I still need to add an example to the README, add to the test and possibly to the test-project.

This currently only adds it to the Apollo codegen. I got a feeling, reading the code, Sangria style is lacking quite a bit more functionality than apollo. 