### PR TITLE
Fix shadowing warning due to redundant import

### DIFF
--- a/src/main/scala/rocks/muki/graphql/codegen/CodeGenStyles.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/CodeGenStyles.scala
@@ -52,7 +52,7 @@ object CodeGenStyles {
       }
     }
 
-    val additionalImports = GraphQLQueryGenerator.imports(context.packageName) ++ customImports
+    val additionalImports = customImports
     val additionalInits = GraphQLQueryGenerator.inits
 
     // Process all the graphql files

--- a/src/main/scala/rocks/muki/graphql/codegen/GraphQLQueryGenerator.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/GraphQLQueryGenerator.scala
@@ -45,20 +45,6 @@ object GraphQLQueryGenerator {
      }"""
 
   /**
-    * Add these imports to your generated code.
-    *
-    * @param packageName the GraphQLQuery package
-    * @return
-    */
-  def imports(packageName: String): List[Import] = {
-    val importer =
-      Importer(Term.Name(packageName), List(Importee.Name(Name(name))))
-    List(
-      q"import ..${List(importer)}"
-    )
-  }
-
-  /**
     * Scala meta `Init` definitions. Use these to extend a generated class with the
     * GraphQLQuery trait.
     */

--- a/src/test/resources/apollo/blog/AddArticle.scala
+++ b/src/test/resources/apollo/blog/AddArticle.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object AddArticle {
   object addArticle extends GraphQLQuery {

--- a/src/test/resources/apollo/blog/BlogArticleQuery.scala
+++ b/src/test/resources/apollo/blog/BlogArticleQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object BlogArticleQuery {
   object BlogArticleQuery extends GraphQLQuery {

--- a/src/test/resources/apollo/blog/BlogByID.scala
+++ b/src/test/resources/apollo/blog/BlogByID.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object BlogByID {
   object Blog extends GraphQLQuery {

--- a/src/test/resources/apollo/starwars-circe/HeroAndFriends.scala
+++ b/src/test/resources/apollo/starwars-circe/HeroAndFriends.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import sangria.macros._

--- a/src/test/resources/apollo/starwars-circe/HeroFragmentQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/HeroFragmentQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import sangria.macros._

--- a/src/test/resources/apollo/starwars-circe/HeroNameQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/HeroNameQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import sangria.macros._

--- a/src/test/resources/apollo/starwars-circe/InputVariables.scala
+++ b/src/test/resources/apollo/starwars-circe/InputVariables.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import sangria.macros._

--- a/src/test/resources/apollo/starwars-circe/SearchQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/SearchQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import sangria.macros._

--- a/src/test/resources/apollo/starwars/HeroAndFriends.scala
+++ b/src/test/resources/apollo/starwars/HeroAndFriends.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object HeroAndFriends {
   object HeroAndFriends extends GraphQLQuery {

--- a/src/test/resources/apollo/starwars/HeroFragmentQuery.scala
+++ b/src/test/resources/apollo/starwars/HeroFragmentQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object HeroFragmentQuery {
   object HeroFragmentQuery extends GraphQLQuery {

--- a/src/test/resources/apollo/starwars/HeroNameQuery.scala
+++ b/src/test/resources/apollo/starwars/HeroNameQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object HeroNameQuery {
   object HeroNameQuery extends GraphQLQuery {

--- a/src/test/resources/apollo/starwars/InputVariables.scala
+++ b/src/test/resources/apollo/starwars/InputVariables.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object InputVariables {
   object InputVariables extends GraphQLQuery {

--- a/src/test/resources/apollo/starwars/SearchQuery.scala
+++ b/src/test/resources/apollo/starwars/SearchQuery.scala
@@ -1,4 +1,3 @@
-import com.example.GraphQLQuery
 import sangria.macros._
 object SearchQuery {
   object SearchQuery extends GraphQLQuery {

--- a/src/test/scala/rocks/muki/graphql/codegen/apollo/ApolloBlogCodegenSpec.scala
+++ b/src/test/scala/rocks/muki/graphql/codegen/apollo/ApolloBlogCodegenSpec.scala
@@ -11,6 +11,6 @@ class ApolloBlogCodegenSpec
       "blog",
       (fileName: String) =>
         ApolloSourceGenerator(fileName,
-                              GraphQLQueryGenerator.imports("com.example"),
+                              Nil,
                               GraphQLQueryGenerator.inits,
                               JsonCodeGens.None))

--- a/src/test/scala/rocks/muki/graphql/codegen/apollo/ApolloCirceStarWarsCodegenSpec.scala
+++ b/src/test/scala/rocks/muki/graphql/codegen/apollo/ApolloCirceStarWarsCodegenSpec.scala
@@ -11,7 +11,7 @@ class ApolloCirceStarWarsCodegenSpec
       "starwars-circe",
       (fileName: String) =>
         ApolloSourceGenerator(fileName,
-                              GraphQLQueryGenerator.imports("com.example"),
+                              Nil,
                               GraphQLQueryGenerator.inits,
                               JsonCodeGens.Circe)
     )

--- a/src/test/scala/rocks/muki/graphql/codegen/apollo/ApolloStarWarsCodegenSpec.scala
+++ b/src/test/scala/rocks/muki/graphql/codegen/apollo/ApolloStarWarsCodegenSpec.scala
@@ -11,7 +11,7 @@ class ApolloStarWarsCodegenSpec
       "starwars",
       (fileName: String) =>
         ApolloSourceGenerator(fileName,
-                              GraphQLQueryGenerator.imports("com.example"),
+                              Nil,
                               GraphQLQueryGenerator.inits,
                               JsonCodeGens.None)
     )


### PR DESCRIPTION
The import of the GraphQLQuery trait is redundant, as it is always generated in the same package. 
Scala gives you a warning about this, which causes the compilation to fail if `-Xfatal-warnings` is set.

This PR simply removes the redundant import under the assumption that the trait is always in the same package and this cannot be changed by configuration.