### PR TITLE
Enable post requests for introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ graphqlProductionSchema := GraphQLSchemaLoader
   .fromIntrospection("http://prod.your-graphql.net/graphql", streams.value.log)
   .withHeaders("X-Api-Version" -> "1", "X-Api-Key" -> "4198ab84-e992-42b0-8742-225ed15a781e")
   .loadSchema()
+  
+// from a graphql endpoint via introspection with post request
+graphqlProductionSchema := GraphQLSchemaLoader
+  .fromIntrospection("http://prod.your-graphql.net/graphql", streams.value.log)
+  .withPost()
+  .loadSchema()
 ```
 
 

--- a/src/main/scala/rocks/muki/graphql/schema/SchemaLoader.scala
+++ b/src/main/scala/rocks/muki/graphql/schema/SchemaLoader.scala
@@ -77,7 +77,8 @@ class FileSchemaLoader(file: File) extends SchemaLoader {
 case class IntrospectSchemaLoader(url: String,
                                   log: Logger,
                                   headers: Seq[(String, String)] = Seq.empty,
-                                  method: IntrospectSchemaLoader.Method = IntrospectSchemaLoader.GET)
+                                  method: IntrospectSchemaLoader.Method =
+                                    IntrospectSchemaLoader.GET)
     extends SchemaLoader {
 
   override def loadSchema(): Schema[Any, Any] =
@@ -103,10 +104,15 @@ case class IntrospectSchemaLoader(url: String,
 
     val response = method match {
       case IntrospectSchemaLoader.POST =>
-        val body = Json.obj("query" -> Json.fromString(introspectionQuery.renderCompact)).noSpaces
+        val body = Json
+          .obj("query" -> Json.fromString(introspectionQuery.renderCompact))
+          .noSpaces
         Http(url).headers(headers).method("POST").postData(body).asString
       case IntrospectSchemaLoader.GET =>
-        Http(url).headers(headers).param("query", introspectionQuery.renderCompact).asString
+        Http(url)
+          .headers(headers)
+          .param("query", introspectionQuery.renderCompact)
+          .asString
     }
 
     parse(response.body) match {
@@ -116,7 +122,8 @@ case class IntrospectSchemaLoader(url: String,
         log.error(error.message)
         log.error("Body received")
         log.error(response.body)
-        sys.error(s"Invalid JSON was returned from graphql endpoint ${method.name} : $url")
+        sys.error(
+          s"Invalid JSON was returned from graphql endpoint ${method.name} : $url")
     }
   }
 }
@@ -126,7 +133,7 @@ object IntrospectSchemaLoader {
   /**
     * http method for introspection query
     */
-    sealed abstract class Method(val name: String)
-    case object POST extends Method("POST")
-    case object GET extends Method("GET")
+  sealed abstract class Method(val name: String)
+  case object POST extends Method("POST")
+  case object GET extends Method("GET")
 }


### PR DESCRIPTION
Enable `post` requests for introspection query

```scala
graphqlProductionSchema := GraphQLSchemaLoader
  .fromIntrospection("http://prod.your-graphql.net/graphql", streams.value.log)
  .withPost()
  .loadSchema()
```