### PR TITLE
FIX #48 Implement magic #import like apollo-graphql

### DIFF
--- a/src/main/scala/rocks/muki/graphql/codegen/CodeGenContext.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/CodeGenContext.scala
@@ -17,6 +17,7 @@ import sbt.Logger
   * @param moduleName optional module name for single-file based generators
   * @param jsonCodeGen
   * @param imports list of imports to be added to the generated file
+  * @param preProcessors pre processors that should be applied before the graphql file is parsed
   * @param log output log
   */
 case class CodeGenContext(
@@ -27,5 +28,6 @@ case class CodeGenContext(
     moduleName: String,
     jsonCodeGen: JsonCodeGen,
     imports: Seq[String],
+    preProcessors: Seq[PreProcessor],
     log: Logger
 )

--- a/src/main/scala/rocks/muki/graphql/codegen/CodeGenStyles.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/CodeGenStyles.scala
@@ -57,7 +57,10 @@ object CodeGenStyles {
     // Process all the graphql files
     val files = inputFiles.map { inputFile =>
       for {
-        queryDocument <- DocumentLoader.single(schema, inputFile)
+        processedFile <- PreProcessors(inputFile,
+                                       context.targetDirectory,
+                                       context.preProcessors)
+        queryDocument <- DocumentLoader.single(schema, processedFile)
         typedDocument <- TypedDocumentParser(schema, queryDocument)
           .parse()
         sourceCode <- ApolloSourceGenerator(inputFile.getName,
@@ -78,7 +81,10 @@ object CodeGenStyles {
 
     val interfaceFile = for {
       // use all queries to determine the interfaces & types we need
-      allQueries <- DocumentLoader.merged(schema, inputFiles.toList)
+      processedFiles <- PreProcessors(inputFiles,
+                                      context.targetDirectory,
+                                      context.preProcessors)
+      allQueries <- DocumentLoader.merged(schema, processedFiles.toList)
       typedDocument <- TypedDocumentParser(schema, allQueries)
         .parse()
       codeGenerator = ApolloSourceGenerator("Interfaces.scala",

--- a/src/main/scala/rocks/muki/graphql/codegen/DocumentLoader.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/DocumentLoader.scala
@@ -59,7 +59,7 @@ object DocumentLoader {
         violations.isEmpty,
         document,
         Failure(
-          s"Invalid query: ${violations.map(_.errorMessage).mkString(", ")}"))
+          s"Invalid query in ${file.getAbsolutePath}:\n${violations.map(_.errorMessage).mkString(", ")}"))
     } yield document
   }
 

--- a/src/main/scala/rocks/muki/graphql/codegen/PreProcessors.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/PreProcessors.scala
@@ -1,0 +1,113 @@
+package rocks.muki.graphql.codegen
+
+import sbt._
+
+import cats.syntax.either._
+
+object PreProcessors {
+
+  /**
+    * Applies all preprocessors and returns a new file with the processed content
+    *
+    * @param graphqlFile the input graphql file
+    * @param targetDir target directory where the processed file should be written
+    * @param preProcessors the list of preprocessors
+    * @return a new file with the processed content
+    */
+  def apply(graphqlFile: File,
+            targetDir: File,
+            preProcessors: Seq[PreProcessor]): Result[File] = {
+    val processedFile = targetDir / graphqlFile.getName
+
+    for {
+      input <- Either.catchNonFatal(IO.read(graphqlFile)).leftMap { error =>
+        Failure(s"Failed to read $graphqlFile: ${error.getMessage}")
+      }
+      // poor-mans traverse
+      processedContent <- preProcessors.foldLeft(Right(input): Result[String]) {
+        case (Right(processedContent), processor) =>
+          processor(processedContent)
+        case (error, _) => error
+      }
+    } yield {
+      IO.write(processedFile, processedContent)
+      processedFile
+    }
+  }
+
+  /**
+    * Applies the preprocessors to all given files
+    *
+    * @param graphqlFiles graphql input files
+    * @param targetDir target directory where the processed file should be written
+    * @param preProcessors the list of preprocessors
+    * @return a list of new files with the processed content
+    */
+  def apply(graphqlFiles: Seq[File],
+            targetDir: File,
+            preProcessors: Seq[PreProcessor]): Result[Seq[File]] = {
+    graphqlFiles
+      .map(file => apply(file, targetDir, preProcessors))
+      .foldLeft[Result[List[File]]](Right(List.empty)) {
+        case (Left(failure), Left(nextFailure)) =>
+          Left(Failure(failure.message + "\n" + nextFailure.message))
+        case (Left(failure), _) => Left(failure)
+        case (_, Left(failure)) => Left(failure)
+        case (Right(files), Right(file)) => Right(files :+ file)
+      }
+  }
+
+  /**
+    * Allows to import other graphql files (e.g. fragments) into an graphql file.
+    *
+    * Allowed characters in the path are
+    * - everything that matches `\w`, e.g. characters, decimals and _
+    * - forward slashes `/`
+    * - dots `.`
+    *
+    * @example {{{
+    *    #import fragments/foo.graphql
+    * }}}
+    * @param rootDirectories a list of directories that should be used to resolve magic imports
+    * @return
+    */
+  def magicImports(rootDirectories: Seq[File]): PreProcessor = graphQLFile => {
+    // match the import file path
+    val Import = "#import\\s*([\\w\\/\\.]*)".r
+
+    val processed = graphQLFile.split(IO.Newline).map {
+      case Import(filePath) =>
+        rootDirectories.map(dir => dir / filePath).find(_.exists()) match {
+          case Some(importedGraphQLFile) =>
+            val importedGraphQLContent = IO.read(importedGraphQLFile)
+            for {
+              recursiveProcessed <- magicImports(rootDirectories)(
+                importedGraphQLContent)
+            } yield recursiveProcessed + IO.Newline
+          case None =>
+            Left(Failure(s"Could not resolve $filePath in $rootDirectories"))
+        }
+      case line => Right(line)
+    }
+
+    // poor mans cats.Validated
+    val errors = processed.collect {
+      case Left(error) => error
+    }
+
+    if (errors.isEmpty) {
+      Right(
+        processed
+          .collect {
+            case Right(line) => line
+          }
+          .mkString(IO.Newline))
+    } else {
+      Left(errors.reduce[Failure] {
+        case (reduced, nextFailure) =>
+          Failure(reduced.message + IO.Newline + reduced.message)
+      })
+    }
+  }
+
+}

--- a/src/main/scala/rocks/muki/graphql/codegen/package.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/package.scala
@@ -17,5 +17,17 @@
 package rocks.muki.graphql
 
 package object codegen {
+
+  /**
+    * Type alias for a processing result during a code generation step
+    * @tparam T the success type
+    */
   type Result[T] = Either[Failure, T]
+
+  /**
+    * Type alias for a graphql file pre-processing function.
+    * _ The input is the raw graphql file content
+    * _ The output is the transformed graphql file content or an error
+    */
+  type PreProcessor = String => Result[String]
 }

--- a/src/sbt-test/codegen/apollo-magic-imports/build.sbt
+++ b/src/sbt-test/codegen/apollo-magic-imports/build.sbt
@@ -1,0 +1,16 @@
+name := "test"
+enablePlugins(GraphQLCodegenPlugin)
+scalaVersion := "2.12.4"
+
+libraryDependencies ++= Seq(
+  "org.sangria-graphql" %% "sangria" % "1.3.0"
+)
+
+graphqlCodegenStyle := Apollo
+
+TaskKey[Unit]("check") := {
+  val generatedFiles = (graphqlCodegen in Compile).value
+  val interfacesFile = generatedFiles.find(_.getName == "Interfaces.scala")
+
+  assert(interfacesFile.isDefined, s"Could not find generated scala class. Available files\n  ${generatedFiles.mkString("\n  ")}")
+}

--- a/src/sbt-test/codegen/apollo-magic-imports/project/plugins.sbt
+++ b/src/sbt-test/codegen/apollo-magic-imports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("rocks.muki" % "sbt-graphql" % sys.props("project.version"))

--- a/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/HeroFragmentQuery.graphql
+++ b/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/HeroFragmentQuery.graphql
@@ -1,0 +1,13 @@
+query HeroFragmentQuery {
+  hero {
+    ...CharacterInfo
+  }
+  human(id: "Lea") {
+    homePlanet
+    ...CharacterInfo
+  }
+}
+
+#import fragments/CharacterFriends.fragment.graphql
+#import fragments/CharacterInfo.fragment.graphql
+

--- a/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/HeroFragmentWithAbsolutQuery.graphql
+++ b/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/HeroFragmentWithAbsolutQuery.graphql
@@ -1,0 +1,12 @@
+query HeroFragmentWithAbsolutQuery {
+  hero {
+    ...CharacterInfoWithAbsolutImport
+  }
+  human(id: "Lea") {
+    homePlanet
+    ...CharacterInfoWithAbsolutImport
+  }
+}
+
+#import fragments/CharacterInfoWithAbsolutImport.fragment.graphql
+

--- a/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/fragments/CharacterFriends.fragment.graphql
+++ b/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/fragments/CharacterFriends.fragment.graphql
@@ -1,0 +1,3 @@
+fragment CharacterFriends on Character {
+    name
+}

--- a/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/fragments/CharacterInfo.fragment.graphql
+++ b/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/fragments/CharacterInfo.fragment.graphql
@@ -1,0 +1,6 @@
+fragment CharacterInfo on Character {
+    name
+    friends {
+        ...CharacterFriends
+    }
+}

--- a/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/fragments/CharacterInfoWithAbsolutImport.fragment.graphql
+++ b/src/sbt-test/codegen/apollo-magic-imports/src/main/graphql/fragments/CharacterInfoWithAbsolutImport.fragment.graphql
@@ -1,0 +1,8 @@
+#import fragments/CharacterFriends.fragment.graphql
+
+fragment CharacterInfoWithAbsolutImport on Character {
+    name
+    friends {
+        ...CharacterFriends
+    }
+}

--- a/src/sbt-test/codegen/apollo-magic-imports/src/main/resources/schema.graphql
+++ b/src/sbt-test/codegen/apollo-magic-imports/src/main/resources/schema.graphql
@@ -1,0 +1,74 @@
+# A character in the Star Wars Trilogy
+interface Character {
+  # The id of the character.
+  id: String!
+
+  # The name of the character.
+  name: String
+
+  # The friends of the character, or an empty list if they have none.
+  friends: [Character!]!
+
+  # Which movies they appear in.
+  appearsIn: [Episode]
+}
+
+# A mechanical creature in the Star Wars universe.
+type Droid implements Character {
+  # The id of the droid.
+  id: String!
+
+  # The name of the droid.
+  name: String
+
+  # The friends of the droid, or an empty list if they have none.
+  friends: [Character!]!
+
+  # Which movies they appear in.
+  appearsIn: [Episode]
+
+  # The primary function of the droid.
+  primaryFunction: String
+}
+
+# One of the films in the Star Wars Trilogy
+enum Episode {
+  # Released in 1977.
+  NEWHOPE
+
+  # Released in 1980.
+  EMPIRE
+
+  # Released in 1983.
+  JEDI
+}
+
+# A humanoid creature in the Star Wars universe.
+type Human implements Character {
+  # The id of the human.
+  id: String!
+
+  # The name of the human.
+  name: String
+
+  # The friends of the human, or an empty list if they have none.
+  friends: [Character!]!
+
+  # Which movies they appear in.
+  appearsIn: [Episode]
+
+  # The home planet of the human, or null if unknown.
+  homePlanet: String
+}
+
+type Query {
+  hero(
+    # If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.
+    episode: Episode): Character! @deprecated(reason: "Use `human` or `droid` fields instead")
+  human(
+    # id of the character
+    id: String!): Human
+  droid(
+    # id of the character
+    id: String!): Droid!
+}

--- a/src/sbt-test/codegen/apollo-magic-imports/test
+++ b/src/sbt-test/codegen/apollo-magic-imports/test
@@ -1,0 +1,3 @@
+> update
+> compile
+> check


### PR DESCRIPTION
# Magic #imports

Fix #48 

This is a feature tries to replicate the [apollographql/graphql-tag loader.js](https://github.com/apollographql/graphql-tag/blob/ae792b67ef16ae23a0a7a8d78af8b698e8acd7d2/loader.js#L29-L37)
feature, which enables including (or actually inlining) partials into a graphql query with magic comments.

## Explained

The syntax is straightforward

```graphql
#import path/to/included.fragment.graphql
```

The fragment files should be named liked this

```
<name>.fragment.graphql
```

There is a `excludeFilter in graphqlCodegen`, which removes them from code generation so they are just used for inlining
and interface generation.

The resolving of paths works like this

- The path is resolved by checking all `sourceDirectories in graphqlCodegen` for the given path
- No relative paths like `./foo.fragment.graphql` are supported
- Imports are resolved recursively. This means you can `#import` fragments in a fragment.

## Example

I have a file `CharacterInfo.fragment.graphql` which contains only a single fragment

```graphql
fragment CharacterInfo on Character {
    name
}
```

And the actual graphql query file


```graphql
query HeroFragmentQuery {
  hero {
    ...CharacterInfo
  }
  human(id: "Lea") {
    homePlanet
    ...CharacterInfo
  }
}

#import fragments/CharacterInfo.fragment.graphql
```