### PR TITLE
Use cats to make some of the document wrangling a bit simpler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,14 @@ organization := "rocks.muki"
 sbtPlugin := true
 
 val circeVersion = "0.9.3"
+val catsVersion = "1.3.1"
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria" % "1.3.2",
   "org.sangria-graphql" %% "sangria-circe" % "1.2.1",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
+  "org.typelevel" %% "cats-core" % catsVersion,
+  "org.typelevel" %% "cats-testkit" % catsVersion % Test,
   "org.scalaj" %% "scalaj-http" % "2.3.0",
   "org.scalameta" %% "scalameta" % "3.7.4",
   "org.scalatest" %% "scalatest" % "3.0.4" % Test
@@ -15,6 +18,8 @@ libraryDependencies ++= Seq(
 
 // scripted test settings
 scriptedLaunchOpts += "-Dproject.version=" + version.value
+
+scalacOptions += "-Ypartial-unification"
 
 // project meta data
 licenses := Seq(

--- a/src/main/scala/rocks/muki/graphql/codegen/Failure.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/Failure.scala
@@ -16,7 +16,34 @@
 
 package rocks.muki.graphql.codegen
 
+import cats.instances.string._
+import cats.{Eq, Semigroup}
+import sbt.io.IO
+
 /**
   * A generic error type for codegen failures.
   */
 case class Failure(message: String) extends Exception(message)
+
+object Failure {
+
+  /**
+    * Useful to combine collections of failures (e.g. NonEmptyList) to one `Failure` using `.reduce`
+    *
+    * {{
+    *   val failures: NonEmptyList[Failure] = ... // possibly from ValidatedNel
+    *
+    *   val combinedFailure: Failure = failures.reduce
+    * }}
+    *
+    * Note: Because of the newline between the two values this doesn't satisfy the Monoid left- and right-identity
+    *       laws and can only be a Semigroup (associativity law).
+    */
+  implicit val semigroupFailure: Semigroup[Failure] =
+    (x: Failure, y: Failure) => Failure(x.message + IO.Newline + y.message)
+
+  /**
+    * Mainly used for law checking in tests
+    */
+  implicit val eqFailure: Eq[Failure] = Eq.by(_.message)
+}

--- a/src/main/scala/rocks/muki/graphql/instances/instances.scala
+++ b/src/main/scala/rocks/muki/graphql/instances/instances.scala
@@ -1,0 +1,17 @@
+package rocks.muki.graphql
+
+import cats.Monoid
+import sangria.ast.Document
+
+package object instances {
+
+  /**
+    * Useful if you want to combine documents using `.combineAll`, `.foldMap` or `.foldMapM`.
+    *
+    * Note that there is also `Documents.merge`, which has nothing to do with cats, but merge multiple Documents as well.
+    */
+  implicit val monoidDocument: Monoid[Document] = new Monoid[Document] {
+    override def empty: Document = Document(Vector.empty)
+    override def combine(x: Document, y: Document): Document = x merge y
+  }
+}

--- a/src/test/scala/rocks/muki/graphql/codegen/FailureInstancesSpec.scala
+++ b/src/test/scala/rocks/muki/graphql/codegen/FailureInstancesSpec.scala
@@ -1,0 +1,12 @@
+package rocks.muki.graphql.codegen
+
+import cats.kernel.laws.discipline.SemigroupTests
+import cats.tests.CatsSuite
+import org.scalacheck.Arbitrary
+
+class FailureInstancesSpec extends CatsSuite {
+  implicit private val failureArb: Arbitrary[Failure] = Arbitrary(
+    Arbitrary.arbString.arbitrary.map(Failure(_)))
+
+  checkAll("Semigroup[Failure]", SemigroupTests[Failure].semigroup)
+}

--- a/src/test/scala/rocks/muki/graphql/instances/DocumentInstancesSpec.scala
+++ b/src/test/scala/rocks/muki/graphql/instances/DocumentInstancesSpec.scala
@@ -1,0 +1,23 @@
+package rocks.muki.graphql.instances
+
+import cats._
+import cats.kernel.laws.discipline.MonoidTests
+import cats.tests.CatsSuite
+import org.scalacheck.{Arbitrary, Gen}
+import rocks.muki.graphql.codegen.style.sangria.TestSchema
+import sangria.ast.Document
+
+class DocumentInstancesSpec extends CatsSuite {
+  implicit private val arbDocument: Arbitrary[Document] =
+    Arbitrary(
+      Gen.oneOf(
+        Document(Vector.empty),
+        Document.emptyStub,
+        Document(TestSchema.StarWarsSchema.toAst.definitions.take(3))
+      )
+    )
+  implicit private val eqDocument: Eq[Document] =
+    Eq.fromUniversalEquals[Document]
+
+  checkAll("Monoid[sangria.ast.Document]", MonoidTests[Document].monoid)
+}


### PR DESCRIPTION
Ok, so this doesn't replace the `Result` type with `cats.Validated` yet, as suggested in #49 but it's already a lot tidier and less ad-hoc error mangling (imo).

Tell me what you think about the diff. I kinda went all-out with cats, so I can understand if you think it's too much.

Note: The `/*_*/ ... /*_*/` tags are an (undocumented?) feature to shut up red squiggles in IntelliJ for only a part of the file. This is really useful if you're using certain cats functions like `sequence`, `traverse` and `foldM`.