### PR TITLE
Use sourceManaged in Compile config for generated renderer

### DIFF
--- a/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
@@ -95,7 +95,7 @@ object GraphQLSchemaPlugin extends AutoPlugin {
   )
 
   /**
-    * Generates a small code snippet that accessres the schema definition in the original
+    * Generates a small code snippet that accesses the schema definition in the original
     * code base and renders it as a graphql schema definition file.
     *
     * @see https://github.com/mediative/sangria-codegen/blob/master/sbt-sangria-codegen/src/main/scala/com.mediative.sangria.codegen.sbt/SangriaSchemagenPlugin.scala#L121-L153
@@ -103,7 +103,7 @@ object GraphQLSchemaPlugin extends AutoPlugin {
     */
   private def generateSchemaGeneratorClass() = Def.task {
     val schemaCode = graphqlSchemaSnippet.value
-    val file = sourceManaged.value / "sbt-sangria-codegen" / s"$mainClass.scala"
+    val file = (sourceManaged in Compile).value / "sbt-sangria-codegen" / s"$mainClass.scala"
 
     val content = s"""|package $packageName
                       |object $mainClass {


### PR DESCRIPTION
Other common plugins that generate source such as sbt-buildinfo use `sourceManaged in Compile`, and it is used in the examples in [the sbt docs](https://www.scala-sbt.org/1.0/docs/Howto-Generating-Files.html). This seems to be the right thing, since using the `Compile` configuration results in `src_managed/main`, which is in `sourceDirectories` by default.

`sourceManaged.value` in sbt-graphql resulted in `target/scala-2.1x/src_managed/sbt-sangria-codegen`—no `main`—and that seems to break expectations of some tools. In my case sbt-scoverage was broken [in this manner] by the `SchemaGen.scala` being outside `sourceDirectories`, and this change resolves the issue.

[in this manner]: https://github.com/scoverage/sbt-scoverage/issues/105