### PR TITLE
Provide configurable filters for schema generation

### DIFF
--- a/src/main/scala/rocks/muki/graphql/schema/SchemaFilters.scala
+++ b/src/main/scala/rocks/muki/graphql/schema/SchemaFilters.scala
@@ -1,0 +1,34 @@
+package rocks.muki.graphql.schema
+
+sealed trait SchemaFilterName {
+  def name: String
+}
+
+/*
+ * The set of filters available to be used in conjunction with `renderPretty` && `renderCompact`
+ * These should follow the `SchemaFilter`(s) available in sangria, defined here:
+ * https://github.com/sangria-graphql/sangria/blob/343d7a59eeb9392573751306f2b485bca2bee75f/src/main/scala/sangria/renderer/SchemaRenderer.scala#L298-L323
+ */
+object SchemaFilters {
+  case object WithoutSangriaBuiltIn extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.withoutSangriaBuiltIn"
+  }
+  case object Default extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.default"
+  }
+  case object WithoutGraphQLBuiltIn extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.withoutGraphQLBuiltIn"
+  }
+  case object WithoutIntrospection extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.withoutIntrospection"
+  }
+  case object BuiltIn extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.builtIn"
+  }
+  case object Introspection extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.introspection"
+  }
+  case object All extends SchemaFilterName {
+    val name = "sangria.renderer.SchemaFilter.all"
+  }
+}

--- a/src/sbt-test/codegen/generate-schema-and-code/build.sbt
+++ b/src/sbt-test/codegen/generate-schema-and-code/build.sbt
@@ -6,7 +6,7 @@ scalaVersion in ThisBuild := "2.12.4"
 val server = project
   .enablePlugins(GraphQLSchemaPlugin)
   .settings(
-    libraryDependencies += "org.sangria-graphql" %% "sangria" % "1.3.2",
+    libraryDependencies += "org.sangria-graphql" %% "sangria" % "1.4.2",
     graphqlSchemaSnippet :=
       "com.example.starwars.TestSchema.StarWarsSchema"
   )

--- a/src/sbt-test/schema/schema-snippet/build.sbt
+++ b/src/sbt-test/schema/schema-snippet/build.sbt
@@ -5,6 +5,6 @@ enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
 graphqlSchemaSnippet := "example.ProductSchema.schema"
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.3.0",
+  "org.sangria-graphql" %% "sangria" % "1.4.2",
   "org.sangria-graphql" %% "sangria-circe" % "1.1.0"
 )

--- a/src/sbt-test/validation/query/build.sbt
+++ b/src/sbt-test/validation/query/build.sbt
@@ -5,6 +5,6 @@ enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
 graphqlSchemaSnippet := "example.ProductSchema.schema"
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.3.0",
+  "org.sangria-graphql" %% "sangria" % "1.4.2",
   "org.sangria-graphql" %% "sangria-circe" % "1.1.0"
 )

--- a/src/sbt-test/validation/schema/build.sbt
+++ b/src/sbt-test/validation/schema/build.sbt
@@ -5,7 +5,7 @@ enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
 graphqlSchemaSnippet := "example.ProductSchema.schema"
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.3.0",
+  "org.sangria-graphql" %% "sangria" % "1.4.2",
   "org.sangria-graphql" %% "sangria-circe" % "1.1.0"
 )
 


### PR DESCRIPTION
When https://github.com/sangria-graphql/sangria/issues/241 was closed, the output of this plugin changed, as the default behavior of `renderPretty` was changed.

This allows a user to chose how they would like their schema rendered by providing one of the available settings.