### PR TITLE
fixed stackoverflow error, running in tests, json encoding

### DIFF
--- a/src/main/scala/rocks/muki/graphql/GraphQLCodegenPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLCodegenPlugin.scala
@@ -40,61 +40,70 @@ object GraphQLCodegenPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
-    graphqlCodegenStyle := Apollo,
-    graphqlCodegenSchema := (resourceDirectory in Compile).value / "schema.graphql",
-    graphqlCodegenJson := JsonCodeGens.None,
-    sourceDirectory in graphqlCodegen := (sourceDirectory in Compile).value / "graphql",
-    sourceDirectories in graphqlCodegen := List(
-      (sourceDirectory in graphqlCodegen).value),
-    includeFilter in graphqlCodegen := "*.graphql",
-    excludeFilter in graphqlCodegen := HiddenFileFilter || "*.fragment.graphql",
-    graphqlCodegenQueries := Defaults
-      .collectFiles(sourceDirectories in graphqlCodegen,
-                    includeFilter in graphqlCodegen,
-                    excludeFilter in graphqlCodegen)
-      .value,
-    sourceGenerators in Compile += graphqlCodegen.taskValue,
-    graphqlCodegenPackage := "graphql.codegen",
-    graphqlCodegenImports := Seq.empty,
-    graphqlCodegenPreProcessors := List(
-      PreProcessors.magicImports((sourceDirectories in graphqlCodegen).value)
-    ),
-    name in graphqlCodegen := "GraphQLCodegen",
-    graphqlCodegen := {
-      val log = streams.value.log
-      val targetDir = (sourceManaged in Compile).value / "sbt-graphql"
-      //val generator = ScalametaGenerator((name in graphqlCodegen).value)
-      val queries = graphqlCodegenQueries.value
-      log.info(s"Generate code for ${queries.length} queries")
-      log.info(
-        s"Use schema ${graphqlCodegenSchema.value} for query validation")
+  def codegenTask(config: Configuration) =
+    inConfig(config)(
+      Seq(
+        sourceGenerators += graphqlCodegen.taskValue,
+        sourceDirectory in graphqlCodegen := sourceDirectory.value / "graphql",
+        sourceDirectories in graphqlCodegen := List(
+          (sourceDirectory in (config, graphqlCodegen)).value),
+        target in graphqlCodegen := sourceManaged.value / "sbt-graphql",
+        graphqlCodegenQueries := Defaults
+          .collectFiles(sourceDirectories in graphqlCodegen,
+                        includeFilter in graphqlCodegen,
+                        excludeFilter in graphqlCodegen)
+          .value,
+        graphqlCodegenPreProcessors in config := List(
+          PreProcessors.magicImports(
+            (sourceDirectories in (config, graphqlCodegen)).value)
+        ),
+        graphqlCodegen in config := {
+          val log = streams.value.log
+          val targetDir = (target in (config, graphqlCodegen)).value
+          //val generator = ScalametaGenerator((name in graphqlCodegen).value)
+          val queries = graphqlCodegenQueries.value
+          val schemaFile = graphqlCodegenSchema.value
+          log.info(s"Generate code for ${queries.length} queries")
+          log.info(s"Use schema $schemaFile for query validation")
 
-      val packageName = graphqlCodegenPackage.value
-      val schema =
-        SchemaLoader.fromFile(graphqlCodegenSchema.value).loadSchema()
+          val packageName = graphqlCodegenPackage.value
+          val schema =
+            SchemaLoader.fromFile(schemaFile).loadSchema()
 
-      val imports = graphqlCodegenImports.value
-      val jsonCodeGen = graphqlCodegenJson.value
-      val preProcessors = graphqlCodegenPreProcessors.value
-      log.info(
-        s"Generating json decoding with: ${jsonCodeGen.getClass.getSimpleName}")
+          val imports = graphqlCodegenImports.value
+          val jsonCodeGen = graphqlCodegenJson.value
+          val preProcessors = graphqlCodegenPreProcessors.value
+          log.info(
+            s"Generating json decoding with: ${jsonCodeGen.getClass.getSimpleName}")
 
-      log.info(s"Adding imports: ${imports.mkString(",")}")
+          log.info(s"Adding imports: ${imports.mkString(",")}")
 
-      val moduleName = (name in graphqlCodegen).value
-      val context = CodeGenContext(schema,
-                                   targetDir,
-                                   queries,
-                                   packageName,
-                                   moduleName,
-                                   jsonCodeGen,
-                                   imports,
-                                   preProcessors,
-                                   log)
+          val moduleName = (name in (config, graphqlCodegen)).value
+          val context = CodeGenContext(schema,
+                                       targetDir,
+                                       queries,
+                                       packageName,
+                                       moduleName,
+                                       jsonCodeGen,
+                                       imports,
+                                       preProcessors,
+                                       log)
 
-      graphqlCodegenStyle.value(context)
-    }
-  )
+          graphqlCodegenStyle.value(context)
+        }
+      ))
+
+  override def projectSettings: Seq[Setting[_]] =
+    Seq(
+      graphqlCodegenStyle := Apollo,
+      graphqlCodegenSchema := (resourceDirectory in Compile).value / "schema.graphql",
+      graphqlCodegenJson := JsonCodeGens.None,
+      includeFilter in graphqlCodegen := "*.graphql",
+      excludeFilter in graphqlCodegen := HiddenFileFilter || "*.fragment.graphql",
+      graphqlCodegenPackage := "graphql.codegen",
+      graphqlCodegenImports := Seq.empty,
+      name in graphqlCodegen := "GraphQLCodegen",
+      graphqlCodegen := (graphqlCodegen in Compile).value
+    ) ++ codegenTask(Compile) ++ codegenTask(Test)
 
 }

--- a/src/test/resources/apollo/starwars-circe/EpisodeEnum.scala
+++ b/src/test/resources/apollo/starwars-circe/EpisodeEnum.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import sangria.macros._
 import types._
 object EpisodeEnum {
@@ -11,9 +11,13 @@ object EpisodeEnum {
   }
 }"""
     case class Variables()
+    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
     case class Data(hero: Hero)
     object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
     case class Hero(name: Option[String], appearsIn: Option[List[Option[Episode]]])
-    object Hero { implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero] }
+    object Hero {
+      implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero]
+      implicit val jsonEncoder: Encoder[Hero] = deriveEncoder[Hero]
+    }
   }
 }

--- a/src/test/resources/apollo/starwars-circe/EpisodeEnumTypes.scala
+++ b/src/test/resources/apollo/starwars-circe/EpisodeEnumTypes.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 object types {
   sealed trait Episode
   object Episode {
@@ -15,6 +15,11 @@ object types {
         Right(JEDI)
       case other =>
         Left("invalid enum value: " + other)
+    })
+    implicit val jsonEncoder: Encoder[Episode] = Encoder.encodeString.contramap({
+      case NEWHOPE => "NEWHOPE"
+      case EMPIRE => "EMPIRE"
+      case JEDI => "JEDI"
     })
   }
 }

--- a/src/test/resources/apollo/starwars-circe/HeroAndFriends.scala
+++ b/src/test/resources/apollo/starwars-circe/HeroAndFriends.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import sangria.macros._
 import types._
 object HeroAndFriends {
@@ -22,22 +22,30 @@ object HeroAndFriends {
   }
 }"""
     case class Variables()
+    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
     case class Data(hero: Hero)
     object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
     case class Hero(name: Option[String], friends: Option[List[Option[Hero.Friends]]])
     object Hero {
       implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero]
+      implicit val jsonEncoder: Encoder[Hero] = deriveEncoder[Hero]
       case class Friends(name: Option[String], friends: Option[List[Option[Friends.Friends]]])
       object Friends {
         implicit val jsonDecoder: Decoder[Friends] = deriveDecoder[Friends]
+        implicit val jsonEncoder: Encoder[Friends] = deriveEncoder[Friends]
         case class Friends(name: Option[String], friends: Option[List[Option[Friends.Friends]]])
         object Friends {
           implicit val jsonDecoder: Decoder[Friends] = deriveDecoder[Friends]
+          implicit val jsonEncoder: Encoder[Friends] = deriveEncoder[Friends]
           case class Friends(name: Option[String], friends: Option[List[Option[Friends.Friends]]])
           object Friends {
             implicit val jsonDecoder: Decoder[Friends] = deriveDecoder[Friends]
+            implicit val jsonEncoder: Encoder[Friends] = deriveEncoder[Friends]
             case class Friends(name: Option[String])
-            object Friends { implicit val jsonDecoder: Decoder[Friends] = deriveDecoder[Friends] }
+            object Friends {
+              implicit val jsonDecoder: Decoder[Friends] = deriveDecoder[Friends]
+              implicit val jsonEncoder: Encoder[Friends] = deriveEncoder[Friends]
+            }
           }
         }
       }

--- a/src/test/resources/apollo/starwars-circe/HeroFragmentQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/HeroFragmentQuery.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import sangria.macros._
 import types._
 object HeroFragmentQuery {
@@ -17,11 +17,18 @@ fragment CharacterInfo on Character {
   name
 }"""
     case class Variables()
+    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
     case class Data(hero: Hero, human: Option[Human])
     object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
     case class Hero(name: Option[String]) extends CharacterInfo
-    object Hero { implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero] }
+    object Hero {
+      implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero]
+      implicit val jsonEncoder: Encoder[Hero] = deriveEncoder[Hero]
+    }
     case class Human(name: Option[String]) extends CharacterInfo
-    object Human { implicit val jsonDecoder: Decoder[Human] = deriveDecoder[Human] }
+    object Human {
+      implicit val jsonDecoder: Decoder[Human] = deriveDecoder[Human]
+      implicit val jsonEncoder: Encoder[Human] = deriveEncoder[Human]
+    }
   }
 }

--- a/src/test/resources/apollo/starwars-circe/HeroNameQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/HeroNameQuery.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import sangria.macros._
 import types._
 object HeroNameQuery {
@@ -10,9 +10,13 @@ object HeroNameQuery {
   }
 }"""
     case class Variables()
+    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
     case class Data(hero: Hero)
     object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
     case class Hero(name: Option[String])
-    object Hero { implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero] }
+    object Hero {
+      implicit val jsonDecoder: Decoder[Hero] = deriveDecoder[Hero]
+      implicit val jsonEncoder: Encoder[Hero] = deriveEncoder[Hero]
+    }
   }
 }

--- a/src/test/resources/apollo/starwars-circe/InputVariables.scala
+++ b/src/test/resources/apollo/starwars-circe/InputVariables.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import sangria.macros._
 import types._
 object InputVariables {
@@ -11,9 +11,13 @@ object InputVariables {
   }
 }"""
     case class Variables(humanId: String)
+    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
     case class Data(human: Option[Human])
     object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
     case class Human(name: Option[String], homePlanet: Option[String])
-    object Human { implicit val jsonDecoder: Decoder[Human] = deriveDecoder[Human] }
+    object Human {
+      implicit val jsonDecoder: Decoder[Human] = deriveDecoder[Human]
+      implicit val jsonEncoder: Encoder[Human] = deriveEncoder[Human]
+    }
   }
 }

--- a/src/test/resources/apollo/starwars-circe/SearchQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/SearchQuery.scala
@@ -1,5 +1,5 @@
-import io.circe.Decoder
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import sangria.macros._
 import types._
 object SearchQuery {
@@ -21,6 +21,7 @@ object SearchQuery {
   }
 }"""
     case class Variables(text: String)
+    object Variables { implicit val jsonEncoder: Encoder[Variables] = deriveEncoder[Variables] }
     case class Data(search: List[Search])
     object Data { implicit val jsonDecoder: Decoder[Data] = deriveDecoder[Data] }
     sealed trait Search {
@@ -29,11 +30,20 @@ object SearchQuery {
     }
     object Search {
       case class Human(__typename: String, name: Option[String], secretBackstory: Option[String]) extends Search
-      object Human { implicit val jsonDecoder: Decoder[Human] = deriveDecoder[Human] }
+      object Human {
+        implicit val jsonDecoder: Decoder[Human] = deriveDecoder[Human]
+        implicit val jsonEncoder: Encoder[Human] = deriveEncoder[Human]
+      }
       case class Droid(__typename: String, name: Option[String], primaryFunction: Option[String]) extends Search
-      object Droid { implicit val jsonDecoder: Decoder[Droid] = deriveDecoder[Droid] }
+      object Droid {
+        implicit val jsonDecoder: Decoder[Droid] = deriveDecoder[Droid]
+        implicit val jsonEncoder: Encoder[Droid] = deriveEncoder[Droid]
+      }
       case class Starship(__typename: String, name: Option[String]) extends Search
-      object Starship { implicit val jsonDecoder: Decoder[Starship] = deriveDecoder[Starship] }
+      object Starship {
+        implicit val jsonDecoder: Decoder[Starship] = deriveDecoder[Starship]
+        implicit val jsonEncoder: Encoder[Starship] = deriveEncoder[Starship]
+      }
       implicit val jsonDecoder: Decoder[Search] = for (typeDiscriminator <- Decoder[String].prepare(_.downField("__typename")); value <- typeDiscriminator match {
         case "Human" =>
           Decoder[Human]


### PR DESCRIPTION
Hey, this is rather uncannonical PR with various changes. Its this way because I was fixing various things as I was trying to use the plugin. I dont expect the PR to be merged right away but submitting anyway :) Maybe will be of some use to someone.

Changes made:
1. recursive use of types cause stack overflow error in `touchType` method (`TypedDocumentParser.scala`). This is probably least controversial change and can be cherrypicked right away.
2. I added json encoders to all the types generated. Its not an optimal solution as encoders are only needed for types included in `Variables` but it was easier to add it everywhere. Relates to #35 
3. I modified the sbt part in a way that allows to use the codegen in both `Compile` and `Test` configuration. From user perspective the change shouldnt be visible as the default `graphqlCodegen` defaults to `compile:graphqlCodegen` but now `test:graphqlCodegen` has also a meanigful implementation that takes queries from test sources and produces output to test results. The only problem I have hit is that `Interfaces` files clashes (you have 2 of those, one for prd and one for test). It wasnt an issue for my particular case because I need it only in tests.