### PR TITLE
Update circe to 0.11.1 while replacing jawn with jackson

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ In your `build.sbt` enable the plugins and add sangria. I'm using circe as a par
 enablePlugins(GraphQLSchemaPlugin, GraphQLQueryPlugin)
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria" % "1.4.2",
-  "org.sangria-graphql" %% "sangria-circe" % "1.2.1"
+  "org.sangria-graphql" %% "sangria" % "1.4.2"
 )
 ``` 
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,12 @@ organization := "rocks.muki"
 sbtPlugin := true
 enablePlugins(SbtPlugin)
 
-val circeVersion = "0.9.3"
-val catsVersion = "1.4.0"
+val circeVersion = "0.11.1"
+val catsVersion = "1.5.0"
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria" % "1.4.2",
-  "org.sangria-graphql" %% "sangria-circe" % "1.2.1",
   "io.circe" %% "circe-core" % circeVersion,
-  "io.circe" %% "circe-parser" % circeVersion,
+  "io.circe" %% "circe-jackson28" % circeVersion,
   "org.typelevel" %% "cats-core" % catsVersion,
   "org.typelevel" %% "cats-testkit" % catsVersion % Test,
   "org.scalaj" %% "scalaj-http" % "2.3.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.1.1")
 
-// plugin project
-libraryDependencies += "org.typelevel" %% "cats-core" % "1.4.0"
-
 // testing
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/rocks/muki/graphql/instances/instances.scala
+++ b/src/main/scala/rocks/muki/graphql/instances/instances.scala
@@ -1,7 +1,9 @@
 package rocks.muki.graphql
 
 import cats.Monoid
+import io.circe.Json
 import sangria.ast.Document
+import sangria.marshalling.InputUnmarshaller
 
 package object instances {
 
@@ -13,5 +15,50 @@ package object instances {
   implicit val monoidDocument: Monoid[Document] = new Monoid[Document] {
     override def empty: Document = Document(Vector.empty)
     override def combine(x: Document, y: Document): Document = x merge y
+  }
+
+  /**
+    * Inlined from sangria-circe 1.2.1, as it is not yet available for circe 0.11.x and it is unclear when it would be.
+    *
+    * We only need this part so no need to inline everything else from `sangria.marshalling.circe._`.
+    */
+  implicit object CirceInputUnmarshaller extends InputUnmarshaller[Json] {
+    def getRootMapValue(node: Json, key: String) = node.asObject.get(key)
+
+    def isMapNode(node: Json) = node.isObject
+    def getMapValue(node: Json, key: String) = node.asObject.get(key)
+    def getMapKeys(node: Json) = node.asObject.get.keys
+
+    def isListNode(node: Json) = node.isArray
+    def getListValue(node: Json) = node.asArray.get
+
+    def isDefined(node: Json) = !node.isNull
+    def getScalarValue(node: Json) = {
+      def invalidScalar =
+        throw new IllegalStateException(s"$node is not a scalar value")
+
+      node.fold(
+        jsonNull = invalidScalar,
+        jsonBoolean = identity,
+        jsonNumber =
+          num ⇒ num.toBigInt orElse num.toBigDecimal getOrElse invalidScalar,
+        jsonString = identity,
+        jsonArray = _ ⇒ invalidScalar,
+        jsonObject = _ ⇒ invalidScalar
+      )
+    }
+
+    def getScalaScalarValue(node: Json) = getScalarValue(node)
+
+    def isEnumNode(node: Json) = node.isString
+
+    def isScalarNode(node: Json) =
+      node.isBoolean || node.isNumber || node.isString
+
+    def isVariableNode(node: Json) = false
+    def getVariableName(node: Json) =
+      throw new IllegalArgumentException("variables are not supported")
+
+    def render(node: Json) = node.noSpaces
   }
 }

--- a/src/main/scala/rocks/muki/graphql/schema/SchemaLoader.scala
+++ b/src/main/scala/rocks/muki/graphql/schema/SchemaLoader.scala
@@ -3,10 +3,10 @@ package rocks.muki.graphql.schema
 import java.io.File
 
 import io.circe.Json
-import io.circe.parser.parse
+import io.circe.jackson.parse
 import sangria.introspection.introspectionQuery
 import sangria.macros._
-import sangria.marshalling.circe._
+import rocks.muki.graphql.instances._
 import sangria.parser.QueryParser
 import sangria.schema.Schema
 import sbt.io.IO


### PR DESCRIPTION
In order to solve the compatibility issues between sbt and `circe-parser` both using different, incompatible versions of jawn (#61), I tried to use `circe-jackson` as a replacement.

I'm using circe 0.11.1 (current stable) here so I also inlined the one thing we need from `sangria-circe`, as it is unclear when that will be updated to circe stable and beyond.

This has the advantage over the shadowing solution proposed in PR #62 that the build stays as simple as possible. Since we remove jawn completely, we don't have to worry about sbt or other sbt-plugins using jawn in the future.

There is a disadvantage compared to shadowing as different circe versions in other sbt-plugins might cause an incompatibility with `sbt-graphql` (circe is not yet fully stable, sadly) . I think this is a normal issue with libraries on the JVM and mostly mitigated by staying up-to-date with the latest stable circe version.

As an aside, I also already built this PR with circe 0.12.0-M4 and cats 2.0.0-M4 and everything seems fine (see here: https://github.com/felixbr/sbt-graphql/commit/fb701b159a7692070813250e34e77eedda5b3ffe).

I hope this makes the whole dependency issue easier going forward 🙂

Cheers
~ Felix