### PR TITLE
Write an utf-8 file in SchemaGen instead of relying on system defaults

### DIFF
--- a/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
@@ -123,15 +123,19 @@ object GraphQLSchemaPlugin extends AutoPlugin {
     val filter = graphqlSchemaGenFilter.value.name
 
     val content = s"""|package $packageName
+                      |
+                      |import java.io._
+                      |import java.nio.charset.StandardCharsets
+                      |
                       |object $mainClass {
                       |  lazy val schema: sangria.schema.Schema[_, _] = {
                       |    $schemaCode
                       |  }
                       |  def main(args: Array[String]): Unit = {
-                      |    val schemaFile = new java.io.File(args(0))
+                      |    val schemaFile = new File(args(0))
                       |    val graphql: String = schema.renderPretty($filter)
                       |    schemaFile.getParentFile.mkdirs()
-                      |    new java.io.PrintWriter(schemaFile) {
+                      |    new PrintWriter(new OutputStreamWriter(new FileOutputStream(schemaFile), StandardCharsets.UTF_8), true) {
                       |      write(graphql)
                       |      close()
                       |    }


### PR DESCRIPTION
I noticed that our schema generation doesn't output utf-8 on my machine (probably some weird locale). Words like "Kündigung" in the documentation of the schema show up as "K?ndigung".

This should fix that (I tried it locally and it worked).