### PR TITLE
Use graphql-compliant schema filter for schema gen

### DIFF
--- a/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
+++ b/src/main/scala/rocks/muki/graphql/GraphQLSchemaPlugin.scala
@@ -3,9 +3,9 @@ package rocks.muki.graphql
 import rocks.muki.graphql.releasenotes.MarkdownReleaseNotes
 import rocks.muki.graphql.schema.SchemaLoader
 import rocks.muki.graphql.schema.SchemaFilterName
+import rocks.muki.graphql.schema.SchemaFilters.WithoutGraphQLBuiltIn
 import sangria.schema._
 import sbt._
-import sangria.renderer.SchemaFilter.default
 import sbt.Keys._
 
 object GraphQLSchemaPlugin extends AutoPlugin {
@@ -78,11 +78,10 @@ object GraphQLSchemaPlugin extends AutoPlugin {
   }
   import autoImport._
   import GraphQLPlugin.autoImport._
-  import rocks.muki.graphql.schema.SchemaFilters.{Default => DefaultSchemaFilter}
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     graphqlSchemaSnippet := """sys.error("Configure the `graphqlSchemaSnippet` setting with the correct scala code snippet to access your sangria schema")""",
-    graphqlSchemaGenFilter := DefaultSchemaFilter,
+    graphqlSchemaGenFilter := WithoutGraphQLBuiltIn,
     graphqlSchemaChanges := graphqlSchemaChangesTask.evaluated,
     target in graphqlSchemaGen := (target in Compile).value / "sbt-graphql",
     graphqlSchemaGen := {

--- a/src/main/scala/rocks/muki/graphql/schema/SchemaFilters.scala
+++ b/src/main/scala/rocks/muki/graphql/schema/SchemaFilters.scala
@@ -13,9 +13,6 @@ object SchemaFilters {
   case object WithoutSangriaBuiltIn extends SchemaFilterName {
     val name = "sangria.renderer.SchemaFilter.withoutSangriaBuiltIn"
   }
-  case object Default extends SchemaFilterName {
-    val name = "sangria.renderer.SchemaFilter.default"
-  }
   case object WithoutGraphQLBuiltIn extends SchemaFilterName {
     val name = "sangria.renderer.SchemaFilter.withoutGraphQLBuiltIn"
   }


### PR DESCRIPTION
The default filter omits Sangria's proprietary built-in (LongType, etc.) scalars from the exported schema, making it incompatible with almost all downstream tooling (e.g. code-generator, etc.) because these types do not exist in the spec and no Javascript tooling understands Scala types.

Change the default schema filter to only exclude official GraphQL for maximum compatibility with other tooling.

This probably breaks compatibility, but I find the current default rather unhelpful.

That said, I'm ok with rejecting this for the sake of compatibility, but in this case I'd appreciate an update to the README which adds the schemaGenFilter setting to README and points out that the default generates a non-compliant schema file.
