### PR TITLE
Updated scalafmt to 2.5.0-RC3 and replaced ⇒ with =>

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,16 @@
-version = 2.0.0
-align = none
+version = 2.5.0-RC3
+project.git = true
+project.excludeFilters = [
+  src/test/resources
+]
+preset = default
 maxColumn = 120
-
-rewrite.rules = [SortImports, RedundantBraces, RedundantParens]
+align.preset = none
+newlines {
+  source = keep
+  alwaysBeforeMultilineDef = false
+}
+rewrite {
+  rules = [SortImports, RedundantBraces, RedundantParens]
+  redundantBraces.generalExpressions = false
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // formatting
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.4")
 
 // releasing
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")

--- a/src/main/scala/rocks/muki/graphql/codegen/ApolloSourceGenerator.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/ApolloSourceGenerator.scala
@@ -201,9 +201,9 @@ case class ApolloSourceGenerator(
         val unionValues = unionTypes.flatMap {
           case TypedDocument.UnionSelection(unionType, unionSelection) =>
             // get nested selections
-            val innerSelections = unionSelection.fields.flatMap(
-              field => selectionStats(field, List.empty)
-            )
+            val innerSelections = unionSelection.fields.flatMap { field =>
+              selectionStats(field, List.empty)
+            }
             val params = generateFieldParams(
               unionSelection.fields,
               typeQualifiers :+ unionName.value

--- a/src/main/scala/rocks/muki/graphql/codegen/PreProcessors.scala
+++ b/src/main/scala/rocks/muki/graphql/codegen/PreProcessors.scala
@@ -21,9 +21,9 @@ object PreProcessors {
         Failure(s"Failed to read $graphqlFile: ${error.getMessage}")
       }
       /*_*/ // Iteratively apply all preprocessors after one another. Fail-fast semantics through Either.
-      processedContent <- preProcessors.toList.foldM(input)(
-        (previousValue, processor) => processor(previousValue)
-      )
+      processedContent <- preProcessors.toList.foldM(input) { (previousValue, processor) =>
+        processor(previousValue)
+      }
       /*_*/
     } yield {
       IO.write(processedFile, processedContent)

--- a/src/main/scala/rocks/muki/graphql/instances/instances.scala
+++ b/src/main/scala/rocks/muki/graphql/instances/instances.scala
@@ -40,10 +40,10 @@ package object instances {
       node.fold(
         jsonNull = invalidScalar,
         jsonBoolean = identity,
-        jsonNumber = num ⇒ num.toBigInt orElse num.toBigDecimal getOrElse invalidScalar,
+        jsonNumber = num => num.toBigInt orElse num.toBigDecimal getOrElse invalidScalar,
         jsonString = identity,
-        jsonArray = _ ⇒ invalidScalar,
-        jsonObject = _ ⇒ invalidScalar
+        jsonArray = _ => invalidScalar,
+        jsonObject = _ => invalidScalar
       )
     }
 

--- a/src/sbt-test/codegen/generate-schema-and-code/server/src/main/scala/com.example.starwars/TestData.scala
+++ b/src/sbt-test/codegen/generate-schema-and-code/server/src/main/scala/com.example.starwars/TestData.scala
@@ -102,22 +102,22 @@ object TestData {
   class FriendsResolver extends DeferredResolver[Any] {
     override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(
       implicit ec: ExecutionContext) = deferred map {
-      case DeferFriends(friendIds) ⇒
-        Future.fromTry(Try(friendIds map (id ⇒ characters.find(_.id == id))))
+      case DeferFriends(friendIds) =>
+        Future.fromTry(Try(friendIds map (id => characters.find(_.id == id))))
     }
   }
 
   class CharacterRepo {
     def getHero(episode: Option[Episode.Value]) =
-      episode flatMap (_ ⇒ getHuman("1000")) getOrElse characters.last
+      episode flatMap (_ => getHuman("1000")) getOrElse characters.last
 
     def getHuman(id: String): Option[Human] =
-      characters.find(c ⇒ c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
+      characters.find(c => c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
 
     def getDroid(id: String): Option[Droid] =
-      characters.find(c ⇒ c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
+      characters.find(c => c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
 
     def getCharacters(ids: Seq[String]): Seq[Character] =
-      ids.flatMap(id ⇒ characters.find(_.id == id))
+      ids.flatMap(id => characters.find(_.id == id))
   }
 }

--- a/src/sbt-test/codegen/generate-schema-and-code/server/src/main/scala/com.example.starwars/TestSchema.scala
+++ b/src/sbt-test/codegen/generate-schema-and-code/server/src/main/scala/com.example.starwars/TestSchema.scala
@@ -41,7 +41,7 @@ object TestSchema {
     InterfaceType(
       "Character",
       "A character in the Star Wars Trilogy",
-      () ⇒
+      () =>
         fields[Unit, TestData.Character](
           Field("id", StringType, Some("The id of the character."), resolve = _.value.id),
           Field(
@@ -53,18 +53,18 @@ object TestSchema {
             "friends",
             OptionType(ListType(OptionType(Character))),
             Some("The friends of the character, or an empty list if they have none."),
-            resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+            resolve = ctx => DeferFriends(ctx.value.friends)
           ),
           Field(
             "appearsIn",
             OptionType(ListType(OptionType(EpisodeEnum))),
             Some("Which movies they appear in."),
-            resolve = _.value.appearsIn map (e ⇒ Some(e))),
+            resolve = _.value.appearsIn map (e => Some(e))),
           Field(
             "secretBackstory",
             OptionType(StringType),
             Some("Where are they from and how they came to be who they are."),
-            resolve = _ ⇒ throw PrivacyError("secretBackstory is secret.")
+            resolve = _ => throw PrivacyError("secretBackstory is secret.")
           )
       ))
 
@@ -84,13 +84,13 @@ object TestSchema {
           "friends",
           OptionType(ListType(OptionType(Character))),
           Some("The friends of the human, or an empty list if they have none."),
-          resolve = (ctx) ⇒ DeferFriends(ctx.value.friends)
+          resolve = (ctx) => DeferFriends(ctx.value.friends)
         ),
         Field(
           "appearsIn",
           OptionType(ListType(OptionType(EpisodeEnum))),
           Some("Which movies they appear in."),
-          resolve = _.value.appearsIn map (e ⇒ Some(e))),
+          resolve = _.value.appearsIn map (e => Some(e))),
         Field(
           "homePlanet",
           OptionType(StringType),
@@ -114,18 +114,18 @@ object TestSchema {
         "name",
         OptionType(StringType),
         Some("The name of the droid."),
-        resolve = ctx ⇒ Future.successful(ctx.value.name)),
+        resolve = ctx => Future.successful(ctx.value.name)),
       Field(
         "friends",
         OptionType(ListType(OptionType(Character))),
         Some("The friends of the droid, or an empty list if they have none."),
-        resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+        resolve = ctx => DeferFriends(ctx.value.friends)
       ),
       Field(
         "appearsIn",
         OptionType(ListType(OptionType(EpisodeEnum))),
         Some("Which movies they appear in."),
-        resolve = _.value.appearsIn map (e ⇒ Some(e))),
+        resolve = _.value.appearsIn map (e => Some(e))),
       Field(
         "primaryFunction",
         OptionType(StringType),
@@ -149,17 +149,17 @@ object TestSchema {
         "hero",
         Character,
         arguments = EpisodeArg :: Nil,
-        resolve = (ctx) ⇒ ctx.ctx.getHero(ctx.arg(EpisodeArg))),
+        resolve = (ctx) => ctx.ctx.getHero(ctx.arg(EpisodeArg))),
       Field(
         "human",
         OptionType(Human),
         arguments = ID :: Nil,
-        resolve = ctx ⇒ ctx.ctx.getHuman(ctx arg ID)),
+        resolve = ctx => ctx.ctx.getHuman(ctx arg ID)),
       Field(
         "droid",
         Droid,
         arguments = ID :: Nil,
-        resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get))
+        resolve = Projector((ctx, f) => ctx.ctx.getDroid(ctx arg ID).get))
     ))
 
   val StarWarsSchema = Schema(Query)

--- a/src/sbt-test/schema/schema-snippet/src/main/scala/example/ProductSchema.scala
+++ b/src/sbt-test/schema/schema-snippet/src/main/scala/example/ProductSchema.scala
@@ -49,7 +49,7 @@ object ProductSchema {
     Field("product", OptionType(ProductType),
       description = Some("Returns a product with specific `id`."),
       arguments = Id :: Nil,
-      resolve = c ⇒ c.ctx.product(c arg Id)),
+      resolve = c => c.ctx.product(c arg Id)),
 
     Field("products", ListType(ProductType),
       description = Some("Returns a list of all available products."),

--- a/src/sbt-test/validation/query/src/main/scala/example/ProductSchema.scala
+++ b/src/sbt-test/validation/query/src/main/scala/example/ProductSchema.scala
@@ -49,7 +49,7 @@ object ProductSchema {
     Field("product", OptionType(ProductType),
       description = Some("Returns a product with specific `id`."),
       arguments = Id :: Nil,
-      resolve = c ⇒ c.ctx.product(c arg Id)),
+      resolve = c => c.ctx.product(c arg Id)),
 
     Field("products", ListType(ProductType),
       description = Some("Returns a list of all available products."),

--- a/src/sbt-test/validation/schema/src/main/scala/example/ProductSchema.scala
+++ b/src/sbt-test/validation/schema/src/main/scala/example/ProductSchema.scala
@@ -49,7 +49,7 @@ object ProductSchema {
     Field("product", OptionType(ProductType),
       description = Some("Returns a product with specific `id`."),
       arguments = Id :: Nil,
-      resolve = c ⇒ c.ctx.product(c arg Id)),
+      resolve = c => c.ctx.product(c arg Id)),
 
     Field("products", ListType(ProductType),
       description = Some("Returns a list of all available products."),

--- a/src/test/scala/rocks/muki/graphql/codegen/style/sangria/TestData.scala
+++ b/src/test/scala/rocks/muki/graphql/codegen/style/sangria/TestData.scala
@@ -105,26 +105,26 @@ object TestData {
   class FriendsResolver extends DeferredResolver[Any] {
     override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) =
       deferred map {
-        case DeferFriends(friendIds) ⇒
-          Future.fromTry(Try(friendIds map (id ⇒ characters.find(_.id == id))))
+        case DeferFriends(friendIds) =>
+          Future.fromTry(Try(friendIds map (id => characters.find(_.id == id))))
       }
   }
 
   class CharacterRepo {
     def getHero(episode: Option[Episode.Value]) =
-      episode flatMap (_ ⇒ getHuman("1000")) getOrElse characters.last
+      episode flatMap (_ => getHuman("1000")) getOrElse characters.last
 
     def getHuman(id: String): Option[Human] =
       characters
-        .find(c ⇒ c.isInstanceOf[Human] && c.id == id)
+        .find(c => c.isInstanceOf[Human] && c.id == id)
         .asInstanceOf[Option[Human]]
 
     def getDroid(id: String): Option[Droid] =
       characters
-        .find(c ⇒ c.isInstanceOf[Droid] && c.id == id)
+        .find(c => c.isInstanceOf[Droid] && c.id == id)
         .asInstanceOf[Option[Droid]]
 
     def getCharacters(ids: Seq[String]): Seq[Character] =
-      ids.flatMap(id ⇒ characters.find(_.id == id))
+      ids.flatMap(id => characters.find(_.id == id))
   }
 }

--- a/src/test/scala/rocks/muki/graphql/codegen/style/sangria/TestSchema.scala
+++ b/src/test/scala/rocks/muki/graphql/codegen/style/sangria/TestSchema.scala
@@ -40,7 +40,7 @@ object TestSchema {
     InterfaceType(
       "Character",
       "A character in the Star Wars Trilogy",
-      () ⇒
+      () =>
         fields[Unit, TestData.Character](
           Field("id", StringType, Some("The id of the character."), resolve = _.value.id),
           Field("name", OptionType(StringType), Some("The name of the character."), resolve = _.value.name),
@@ -48,19 +48,19 @@ object TestSchema {
             "friends",
             OptionType(ListType(OptionType(Character))),
             Some("The friends of the character, or an empty list if they have none."),
-            resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+            resolve = ctx => DeferFriends(ctx.value.friends)
           ),
           Field(
             "appearsIn",
             OptionType(ListType(OptionType(EpisodeEnum))),
             Some("Which movies they appear in."),
-            resolve = _.value.appearsIn map (e ⇒ Some(e))
+            resolve = _.value.appearsIn map (e => Some(e))
           ),
           Field(
             "secretBackstory",
             OptionType(StringType),
             Some("Where are they from and how they came to be who they are."),
-            resolve = _ ⇒ throw PrivacyError("secretBackstory is secret.")
+            resolve = _ => throw PrivacyError("secretBackstory is secret.")
           )
         )
     )
@@ -77,13 +77,13 @@ object TestSchema {
           "friends",
           OptionType(ListType(OptionType(Character))),
           Some("The friends of the human, or an empty list if they have none."),
-          resolve = (ctx) ⇒ DeferFriends(ctx.value.friends)
+          resolve = ctx => DeferFriends(ctx.value.friends)
         ),
         Field(
           "appearsIn",
           OptionType(ListType(OptionType(EpisodeEnum))),
           Some("Which movies they appear in."),
-          resolve = _.value.appearsIn map (e ⇒ Some(e))
+          resolve = _.value.appearsIn map (e => Some(e))
         ),
         Field(
           "homePlanet",
@@ -104,19 +104,19 @@ object TestSchema {
         "name",
         OptionType(StringType),
         Some("The name of the droid."),
-        resolve = ctx ⇒ Future.successful(ctx.value.name)
+        resolve = ctx => Future.successful(ctx.value.name)
       ),
       Field(
         "friends",
         OptionType(ListType(OptionType(Character))),
         Some("The friends of the droid, or an empty list if they have none."),
-        resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+        resolve = ctx => DeferFriends(ctx.value.friends)
       ),
       Field(
         "appearsIn",
         OptionType(ListType(OptionType(EpisodeEnum))),
         Some("Which movies they appear in."),
-        resolve = _.value.appearsIn map (e ⇒ Some(e))
+        resolve = _.value.appearsIn map (e => Some(e))
       ),
       Field(
         "primaryFunction",
@@ -139,9 +139,9 @@ object TestSchema {
   val Query = ObjectType[CharacterRepo, Unit](
     "Query",
     fields[CharacterRepo, Unit](
-      Field("hero", Character, arguments = EpisodeArg :: Nil, resolve = (ctx) ⇒ ctx.ctx.getHero(ctx.arg(EpisodeArg))),
-      Field("human", OptionType(Human), arguments = ID :: Nil, resolve = ctx ⇒ ctx.ctx.getHuman(ctx arg ID)),
-      Field("droid", Droid, arguments = ID :: Nil, resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get))
+      Field("hero", Character, arguments = EpisodeArg :: Nil, resolve = ctx => ctx.ctx.getHero(ctx.arg(EpisodeArg))),
+      Field("human", OptionType(Human), arguments = ID :: Nil, resolve = ctx => ctx.ctx.getHuman(ctx arg ID)),
+      Field("droid", Droid, arguments = ID :: Nil, resolve = Projector((ctx, f) => ctx.ctx.getDroid(ctx arg ID).get))
     )
   )
 

--- a/test-project/server/src/main/scala/example/ProductSchema.scala
+++ b/test-project/server/src/main/scala/example/ProductSchema.scala
@@ -30,8 +30,8 @@ object LocalDateTimeScalar {
   case object LocalDateTimeCoercionViolation extends ValueCoercionViolation("LocalDateTime value expected")
 
   private def parseDate(s: String) = Try(LocalDateTime.parse(s)) match {
-    case Success(date) ⇒ Right(date)
-    case Failure(_) ⇒ Left(LocalDateTimeCoercionViolation)
+    case Success(date) => Right(date)
+    case Failure(_) => Left(LocalDateTimeCoercionViolation)
   }
 
   val LocalDateTimeType = ScalarType[LocalDateTime]("LocalDateTime",
@@ -39,11 +39,11 @@ object LocalDateTimeScalar {
       if (caps.contains(DateSupport)) localDateTime.toLocalDate
       else DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(localDateTime),
     coerceUserInput = {
-      case s: String ⇒ parseDate(s)
+      case s: String => parseDate(s)
       case _ => Left(LocalDateTimeCoercionViolation)
     },
     coerceInput = {
-      case ast.StringValue(s, _, _, _, _) ⇒ parseDate(s)
+      case ast.StringValue(s, _, _, _, _) => parseDate(s)
       case _ => Left(LocalDateTimeCoercionViolation)
     })
 
@@ -85,7 +85,7 @@ object ProductSchema {
     Field("product", OptionType(ProductType),
       description = Some("Returns a product with specific `id`."),
       arguments = Id :: Nil,
-      resolve = c ⇒ c.ctx.product(c arg Id)),
+      resolve = c => c.ctx.product(c arg Id)),
 
     Field("products", ListType(ProductType),
       description = Some("Returns a list of all available products."),

--- a/test-project/server/src/main/scala/example/StarWarsSchema.scala
+++ b/test-project/server/src/main/scala/example/StarWarsSchema.scala
@@ -28,7 +28,7 @@ object StarWarsSchema {
     InterfaceType(
       "Character",
       "A character in the Star Wars Trilogy",
-      () ⇒
+      () =>
         fields[Unit, TestData.Character](
           Field("id",
                 StringType,
@@ -43,12 +43,12 @@ object StarWarsSchema {
             OptionType(ListType(OptionType(Character))),
             Some(
               "The friends of the character, or an empty list if they have none."),
-            resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+            resolve = ctx => DeferFriends(ctx.value.friends)
           ),
           Field("appearsIn",
                 OptionType(ListType(OptionType(EpisodeEnum))),
                 Some("Which movies they appear in."),
-                resolve = _.value.appearsIn map (e ⇒ Some(e)))
+                resolve = _.value.appearsIn map (e => Some(e)))
       )
     )
 
@@ -70,12 +70,12 @@ object StarWarsSchema {
           "friends",
           OptionType(ListType(OptionType(Character))),
           Some("The friends of the human, or an empty list if they have none."),
-          resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+          resolve = ctx => DeferFriends(ctx.value.friends)
         ),
         Field("appearsIn",
               OptionType(ListType(OptionType(EpisodeEnum))),
               Some("Which movies they appear in."),
-              resolve = _.value.appearsIn map (e ⇒ Some(e))),
+              resolve = _.value.appearsIn map (e => Some(e))),
         Field("homePlanet",
               OptionType(StringType),
               Some("The home planet of the human, or null if unknown."),
@@ -96,17 +96,17 @@ object StarWarsSchema {
       Field("name",
             OptionType(StringType),
             Some("The name of the droid."),
-            resolve = ctx ⇒ Future.successful(ctx.value.name)),
+            resolve = ctx => Future.successful(ctx.value.name)),
       Field(
         "friends",
         OptionType(ListType(OptionType(Character))),
         Some("The friends of the droid, or an empty list if they have none."),
-        resolve = ctx ⇒ DeferFriends(ctx.value.friends)
+        resolve = ctx => DeferFriends(ctx.value.friends)
       ),
       Field("appearsIn",
             OptionType(ListType(OptionType(EpisodeEnum))),
             Some("Which movies they appear in."),
-            resolve = _.value.appearsIn map (e ⇒ Some(e))),
+            resolve = _.value.appearsIn map (e => Some(e))),
       Field("primaryFunction",
             OptionType(StringType),
             Some("The primary function of the droid."),
@@ -129,15 +129,15 @@ object StarWarsSchema {
       Field("hero",
             Character,
             arguments = EpisodeArg :: Nil,
-            resolve = ctx ⇒ ctx.ctx.getHero(ctx.arg(EpisodeArg))),
+            resolve = ctx => ctx.ctx.getHero(ctx.arg(EpisodeArg))),
       Field("human",
             OptionType(Human),
             arguments = ID :: Nil,
-            resolve = ctx ⇒ ctx.ctx.getHuman(ctx arg ID)),
+            resolve = ctx => ctx.ctx.getHuman(ctx arg ID)),
       Field("droid",
             Droid,
             arguments = ID :: Nil,
-            resolve = Projector((ctx, f) ⇒ ctx.ctx.getDroid(ctx arg ID).get))
+            resolve = Projector((ctx, f) => ctx.ctx.getDroid(ctx arg ID).get))
     )
   )
 
@@ -216,19 +216,19 @@ object TestData {
 
   class FriendsResolver extends DeferredResolver[Any] {
     override def resolve(deferred: Vector[Deferred[Any]], ctx: Any, queryState: Any)(implicit ec: ExecutionContext) = deferred map {
-      case DeferFriends(friendIds) ⇒
-        Future.fromTry(Try(friendIds map (id ⇒ characters.find(_.id == id))))
+      case DeferFriends(friendIds) =>
+        Future.fromTry(Try(friendIds map (id => characters.find(_.id == id))))
     }
   }
 
   class CharacterRepo {
     def getHero(episode: Option[Episode.Value]) =
-      episode flatMap (_ ⇒ getHuman("1000")) getOrElse characters.last
+      episode flatMap (_ => getHuman("1000")) getOrElse characters.last
 
-    def getHuman(id: String): Option[Human] = characters.find(c ⇒ c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
+    def getHuman(id: String): Option[Human] = characters.find(c => c.isInstanceOf[Human] && c.id == id).asInstanceOf[Option[Human]]
 
-    def getDroid(id: String): Option[Droid] = characters.find(c ⇒ c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
+    def getDroid(id: String): Option[Droid] = characters.find(c => c.isInstanceOf[Droid] && c.id == id).asInstanceOf[Option[Droid]]
 
-    def getCharacters(ids: Seq[String]): Seq[Character] = ids.flatMap(id ⇒ characters.find(_.id == id))
+    def getCharacters(ids: Seq[String]): Seq[Character] = ids.flatMap(id => characters.find(_.id == id))
   }
 }


### PR DESCRIPTION
Hey :-)

This is a PR aiming to update the scalafmt to the newest version with the proper configuration whereas I try to minimize the code formatting changes as possible.

And as the unicode arrow is deprecated since Scala 2.13, I've replaced all occurrences of `⇒` by `=>`. See https://github.com/scala/scala/pull/7540.

