### PR TITLE
Add circe Encoder for unions

### DIFF
--- a/src/test/resources/apollo/starwars-circe/SearchQuery.scala
+++ b/src/test/resources/apollo/starwars-circe/SearchQuery.scala
@@ -54,6 +54,14 @@ object SearchQuery {
         case other =>
           Decoder.failedWithMessage("invalid type: " + other)
       }) yield value
+      implicit val jsonEncoder: Encoder[Search] = Encoder.instance[Search]({
+        case v: Human =>
+          deriveEncoder[Human].apply(v)
+        case v: Droid =>
+          deriveEncoder[Droid].apply(v)
+        case v: Starship =>
+          deriveEncoder[Starship].apply(v)
+      })
     }
   }
 }


### PR DESCRIPTION
This fixes an issue where compilation fails because one of the generated Encoders references a union for which we didn't generate an `Encoder´.

It also makes application testing easier, as everything has `Encoder` instances now, so generating test-json is simple.

I've also verified locally that it fixes these issues in our internal codebase. 🙂